### PR TITLE
Added instructions for install on MacOS + New plot in Jupyter notebook

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,14 +10,55 @@ or problem and please share your improvements to the code!
 and help-you study the state of your data.
 + `environment.yml`: this will install with conda the necessary libraries to run
 the code of this repository.
++ `environment-mac.yml`: this will install with conda necessary libraries for MacOS X systems *except for the `plyvel` library*
 
 ## Install Environment
-
+### Linux
 
 You must also install [leveldb](https://github.com/google/leveldb) to use the
-fah-progress.ipynb.
+fah-progress.ipynb. 
+
 ``` bash
 conda env create -f environment.yml
-conda activate folding_at_home_scripts
-ipython kernel install --user --name=folding_at_home_scripts
+conda activate fah-leveldb
+ipython kernel install --user --name=fah-leveldb
 ```
+
+### MacOS X - by Sukrit Singh (sukrit.singh@choderalab.org)
+
+To install [leveldb](https://github.com/google/leveldb) on MacOS, you can use [Homebrew](https://brew.sh/)
+```
+brew install leveldb
+```
+
+Then to actually install the environment:
+``` bash
+conda env create -f environment-mac.yml
+conda activate fah-leveldb
+ipython kernel install --user --name=fah-leveldb
+```
+
+However, you must do a manual installation of the `plyvel` library due to differences in the Darwin OS.
+
+Next, download the [`plyvel`](https://github.com/wbolster/plyvel) library manually from the github page.
+
+Unzip and navigate into the `plyvel` package:
+```
+unzip plyvel-master.zip
+cd plyvel-master
+```
+
+Next, in `plyvel-master/setup.py`, replace *Line 17* with an updated version:
+```
+extra_compile_args = ['-Wall', '-g', '-x', 'c++', '-std=c++11', '-fno-rtti']
+```
+
+Save the updated `setup.py` and run the following commands in the same directory where `setup.py` is:
+```
+make
+python setup.py install
+```
+
+You can test whether plyvel works using `python -c 'import plyvel'` - this should return no output if everything worked!
+
+Now feel free to use `fah-progress.ipynb` for anything you want!

--- a/environment-mac.yml
+++ b/environment-mac.yml
@@ -13,5 +13,4 @@ dependencies:
   - python=3.8.5
   - tqdm
   - pip:
-    - plyvel
     - nb_black

--- a/fah-progress.ipynb
+++ b/fah-progress.ipynb
@@ -2,12 +2,11 @@
  "cells": [
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 2,
    "id": "30fb6049-1b72-4441-9143-ac88c6c94b79",
    "metadata": {},
    "outputs": [],
    "source": [
-    "%load_ext lab_black\n",
     "import plyvel\n",
     "import pandas as pd\n",
     "import subprocess\n",
@@ -15,6 +14,17 @@
     "import ast\n",
     "import numpy as np\n",
     "import matplotlib.pyplot as plt"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 22,
+   "id": "8ff794dd",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "plt.rcParams.update({'font.size': 22})\n",
+    "#plt.rcParams.update({'size': (10,10)})\n"
    ]
   },
   {
@@ -40,23 +50,33 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 3,
    "id": "26d412b6-5e34-439b-94c5-e216d5dc12ed",
    "metadata": {},
    "outputs": [],
    "source": [
-    "project_number = 16815\n",
-    "rsync_path = \"banhof:/home/server/server2/data/SVR2997798026/work.leveldb/\"\n",
-    "project_path = f\"banhof:/home/server/server2/projects/p{project_number}/project.xml\"\n",
+    "project_number = 16465\n",
+    "rsync_path = \"lilac:/home/singhs15/scratch/work-server-db/pllwskifah2/work.leveldb\"\n",
+    "project_path = (\n",
+    "    f\"lilac:/home/singhs15/scratch/work-server-db/pllwskifah2/{project_number}-project.xml\"\n",
+    ")\n",
     "# rsync_path = \"/home/sergio/bin/\""
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 4,
    "id": "01bd43d7-0cf3-4405-b659-79a285a1af21",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "rsync -uiha --del lilac:/home/singhs15/scratch/work-server-db/pllwskifah2/work.leveldb work.level.db/\n"
+     ]
+    }
+   ],
    "source": [
     "print(f\"rsync -uiha --del {rsync_path} work.level.db/\")"
    ]
@@ -71,14 +91,27 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 5,
    "id": "3a2bda5b-2d5a-496f-af33-1d7abfbd5375",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "###############\n",
+      "Return code scp work.level.db: 0\n",
+      "###############\n",
+      "Return code scp project.xml: 0\n",
+      "###############\n",
+      "Output: \n"
+     ]
+    }
+   ],
    "source": [
     "output = subprocess.run(\"rm -rf work.level.db/\", shell=True)\n",
     "output = subprocess.run(\n",
-    "    f\"scp -r {rsync_path} work.level.db/\", capture_output=True, shell=True\n",
+    "    f\"scp -r {rsync_path} ./work.level.db/\", capture_output=True, shell=True\n",
     ")\n",
     "print(\"###############\")\n",
     "print(\"Return code scp work.level.db:\", output.returncode)\n",
@@ -93,20 +126,150 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 6,
    "id": "05b6080f-cd43-4a65-889d-bb6a503d978a",
    "metadata": {},
    "outputs": [],
    "source": [
-    "db = plyvel.DB(\"./work.level.db\", create_if_missing=False)"
+    "db = plyvel.DB(\"/Users/sukrit/work/scripts/choderalab/folding_at_home_scripts/work.level.db\", create_if_missing=False)"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 7,
    "id": "ea1f2245-b6e6-4546-bf3d-1276dc303952",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "data": {
+      "text/html": [
+       "<div>\n",
+       "<style scoped>\n",
+       "    .dataframe tbody tr th:only-of-type {\n",
+       "        vertical-align: middle;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe tbody tr th {\n",
+       "        vertical-align: top;\n",
+       "    }\n",
+       "\n",
+       "    .dataframe thead th {\n",
+       "        text-align: right;\n",
+       "    }\n",
+       "</style>\n",
+       "<table border=\"1\" class=\"dataframe\">\n",
+       "  <thead>\n",
+       "    <tr style=\"text-align: right;\">\n",
+       "      <th></th>\n",
+       "      <th>server</th>\n",
+       "      <th>state</th>\n",
+       "      <th>project</th>\n",
+       "      <th>core</th>\n",
+       "      <th>run</th>\n",
+       "      <th>clone</th>\n",
+       "      <th>gen</th>\n",
+       "      <th>retries</th>\n",
+       "      <th>assigns</th>\n",
+       "      <th>progress</th>\n",
+       "      <th>assigned</th>\n",
+       "    </tr>\n",
+       "  </thead>\n",
+       "  <tbody>\n",
+       "    <tr>\n",
+       "      <th>0</th>\n",
+       "      <td>2359493842</td>\n",
+       "      <td>READY</td>\n",
+       "      <td>16465</td>\n",
+       "      <td>34</td>\n",
+       "      <td>0</td>\n",
+       "      <td>0</td>\n",
+       "      <td>100</td>\n",
+       "      <td>0</td>\n",
+       "      <td>147</td>\n",
+       "      <td>0.400</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>1</th>\n",
+       "      <td>2359493842</td>\n",
+       "      <td>READY</td>\n",
+       "      <td>16465</td>\n",
+       "      <td>34</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1</td>\n",
+       "      <td>82</td>\n",
+       "      <td>1</td>\n",
+       "      <td>124</td>\n",
+       "      <td>0.328</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>2</th>\n",
+       "      <td>2359493842</td>\n",
+       "      <td>READY</td>\n",
+       "      <td>16465</td>\n",
+       "      <td>34</td>\n",
+       "      <td>0</td>\n",
+       "      <td>10</td>\n",
+       "      <td>86</td>\n",
+       "      <td>0</td>\n",
+       "      <td>128</td>\n",
+       "      <td>0.344</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>3</th>\n",
+       "      <td>2359493842</td>\n",
+       "      <td>READY</td>\n",
+       "      <td>16465</td>\n",
+       "      <td>34</td>\n",
+       "      <td>0</td>\n",
+       "      <td>100</td>\n",
+       "      <td>95</td>\n",
+       "      <td>1</td>\n",
+       "      <td>138</td>\n",
+       "      <td>0.380</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "    <tr>\n",
+       "      <th>4</th>\n",
+       "      <td>2359493842</td>\n",
+       "      <td>FAILED</td>\n",
+       "      <td>16465</td>\n",
+       "      <td>34</td>\n",
+       "      <td>0</td>\n",
+       "      <td>1000</td>\n",
+       "      <td>99</td>\n",
+       "      <td>4</td>\n",
+       "      <td>147</td>\n",
+       "      <td>0.396</td>\n",
+       "      <td>NaN</td>\n",
+       "    </tr>\n",
+       "  </tbody>\n",
+       "</table>\n",
+       "</div>"
+      ],
+      "text/plain": [
+       "       server   state  project  core  run  clone  gen  retries  assigns  \\\n",
+       "0  2359493842   READY    16465    34    0      0  100        0      147   \n",
+       "1  2359493842   READY    16465    34    0      1   82        1      124   \n",
+       "2  2359493842   READY    16465    34    0     10   86        0      128   \n",
+       "3  2359493842   READY    16465    34    0    100   95        1      138   \n",
+       "4  2359493842  FAILED    16465    34    0   1000   99        4      147   \n",
+       "\n",
+       "   progress assigned  \n",
+       "0     0.400      NaN  \n",
+       "1     0.328      NaN  \n",
+       "2     0.344      NaN  \n",
+       "3     0.380      NaN  \n",
+       "4     0.396      NaN  "
+      ]
+     },
+     "execution_count": 7,
+     "metadata": {},
+     "output_type": "execute_result"
+    }
+   ],
    "source": [
     "l = []\n",
     "for key, value in db:\n",
@@ -121,10 +284,18 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 8,
    "id": "f0c6dae8-1ede-452f-a38f-79e165581f6f",
    "metadata": {},
-   "outputs": [],
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "P16465 has 1 runs with 4000 clones and 250 gens.\n"
+     ]
+    }
+   ],
    "source": [
     "file = open(\"work.level.db/project.xml\", \"r\")\n",
     "for line in file:\n",
@@ -143,17 +314,32 @@
   {
    "cell_type": "markdown",
    "id": "22c82ac4-e593-4bbe-8ab1-5dc9ccdae0c1",
-   "metadata": {},
+   "metadata": {
+    "heading_collapsed": true
+   },
    "source": [
     "## Progress of project"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 36,
    "id": "5306448d-03eb-4ba8-a35a-bedc6ef65020",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "hidden": true
+   },
+   "outputs": [
+    {
+     "name": "stdout",
+     "output_type": "stream",
+     "text": [
+      "Finished 0 clones which is 0.0 % of clones.\n",
+      "Finished 406625 WU which is 40.7 % of clones.\n",
+      "Failed 706 clones which is 17.6 % of clones.\n",
+      "Assigned 0 clones which is 0.0 % of clones.\n"
+     ]
+    }
+   ],
    "source": [
     "finished_clones = df[np.logical_and(df.gen == n_gens, df.state == \"FINISHED\")].shape[0]\n",
     "print(\n",
@@ -176,10 +362,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 37,
    "id": "25e64ed5-d21f-469f-8dbc-61733ef9bc44",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "hidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5, 1.0, 'Probability distribution of clones')"
+      ]
+     },
+     "execution_count": 37,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAY4AAAEWCAYAAABxMXBSAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAlV0lEQVR4nO3dfbwWdZ3/8ddbvMtS0UBFQI836IabGiGwa1tmd0AltmVJN95kEgZldyrdbNrNtq66tT/LJFRUVpOsvKGV9SZbtdpQ0BRFo06EeYTiaIU3lIR+fn/M9+hwed3MHM4cDue8n4/H9TjXzHy/3/nMcHF9rvnOzHcUEZiZmRW11eYOwMzMtixOHGZmVooTh5mZleLEYWZmpThxmJlZKU4cZmZWihOH9RhJIWn/btZdKemNDZb9k6Tl9cpK+qyki7sXccuY2tI2bZ2m/0fS8T3UdsNt6qH2l0k6oqfaK7hOSbpU0p8k3VWybo9uv1Vr680dgG1eklYCuwPPAk8DC4GPRsRTmzOuvIj4CXBgg2Vf7XovqQ34LbBNRGyoII5JRcpJCmBURLQ3aavhNpUl6TKgIyI+n2v/oJ5ou6TXAG8CRkTE05th/dZLfMRhAG+PiJcBY4DDgM/XFuj61W2brh/vy72BlU4a/Z8Thz0vIh4F/gf4e3i+62mGpF8Dv07zTpbULumPkhZI2rOmmcmSVkh6TNK5krZK9faT9GNJj6dlV0oaXFP3MEkPpq6OSyVtn+oeIamjXsySzpJ0RZq8I/39s6SnJL0uxfnKXPndJP1F0tA6bQ2SdF6KbwXw1prlt0n6UHq/v6TbJa1N5b+b5nfFcF+K4T1d8Us6Q9LvgUsbbFOj7T9B0k9rYokUwzTgfcDpaX0/TMvz3XnbSfpPSavS6z8lbZfft5I+JWmNpNWSTqy3r1P5PdO/+x/T5+DkNP8k4GLgH1IcX2xQ/2RJD0l6Mm3rmDpluh1vqnuepN9J+oOk2ZJekpYNkfTfkv6c4v9J1+fTyvFOs+dJGglMBn6Rm300MB4YLelI4N+AdwPDgIeB+TXNvAMYS3b0MgX4YFfzqe6ewCuAkcBZNXXfB7wF2A84gDpHPi28Nv0dHBEvi4jbU3zvz5WZCvwoIjrr1D8ZeBvwqrQN72qyri8DNwO7ACOAbwBERFcMh6QYvpum9wB2JftVPq1Bm6W3PyLmAFcC56T1vb1Osc8BE4BDgUOAcTVt7wHsDAwHTgIukLRLg1VeBXSQ/Tu+C/iqpDdExCXAdODnKY4zaytKOobs3/w4YCfgKODxHo7338n23aHA/qnMF9KyT6XYh5J1z34W8JhL3RERfg3gF7ASeAr4M1ki+BbwkrQsgCNzZS8h+4Lqmn4Z8DegLVd+Ym75R4BbG6z3aOAXNXFMz01PBn6T3h9B1oefL/vG9P4s4Ir0vi3FsHWu7HjgEWCrNL0EeHeDmH5cE8Ob8+0BtwEfSu/nAXPI+vNr2wlg/9z0EcB6YPuaebXb1Gj7TwB+2mgdwGXAV+r8u3bto98Ak3PL3kLWpdQVx19q9tkaYEKd7RpJdi5sx9y8fwMuaxRnTf2bgFObfA43KV6yHydPA/vllv0D8Nv0/kvA9fl/G7+69/IRhwEcHRGDI2LviPhIRPwlt+yR3Ps9yZILAJGdQH+c7FddvfIPpzpdXUTzJT0q6QngCmBITRx1626KiLiT7MvkdZL+juxX6IIGxfesE0Mjp5N9Ud2l7AqmDzYpC9AZEX9tUabHtz/Z6N+tTtuPx8YXE6wj+1FQr50/RsSTNW0Nr1O2npFkSaGV7sY7FNgBuDt1R/0ZuDHNBzgXaAduTt2pswrGbTWcOKyV/KH8KrKuFgAkvRR4OfBorszI3Pu9Uh3IfpkGcHBE7ETWfaSadTWq251Y8y5P6/sA8P0mX+Cr68RQf0URv4+IkyNiT+DDwLfU/FLkIl0ijbb/abIvRAAk7VGy7Y3+3ejevu1qZ1dJO9a09WiD8rUeIeuGK7Ke7sT7GNnRyEHph9DgiNg5sgs/iIgnI+JTEbEv8Hbgk5LeUDB2y3HisDK+A5wo6dB0svKrwJ0RsTJX5jRJu6TzJacCXX38O5K6xCQNB06r0/4MSSMk7UrW//zdOmWa6QSeA/atmf9fZOde3k/WxdTI1cDHUgy7AA1/kUo6RtKINPknsi/vZ9P0H+rEUESj7b8POCjt9+158bmhVuu7Cvi8pKGShpD1+V/RpHxdEfEI8H/Av0naXtLBZOcYrizYxMXApyW9Wpn9Je1dp1y34o2I54CLgK9L2g1A0nBJb0nv35bWKeAJsn+vZxs2aA05cVhhEXEr8C/AD8h+ne8HHFtT7HrgbuBe4Aay8yIAXyQ7Yb42zb+mziq+Q3bCeUV6faVkfOuAfwV+lroqJqT5HcA9ZF/uP2nSxEVk/fD3pfL1YuxyGHCnpKfIur5OjYjfpmVnAZenGN5dYhPqbn9E/Iqsf/5HZFe3/bSm3iVkFy/8WdJ1ddr9Ctm5naXA/WnbSu3bnKlk55JWAdcCZ0bELUUqRsT3yP59vgM8CVxHdsFAT8Z7Bll31KLUJfojXrhfZlSafgr4OfCtiLitYLuWo3TSyKxfkzQXWBW5m+TMrHv6641IZs9Tdkf5P5NdZmtmm8hdVdavSfoy8ABwbq4rycw2gbuqzMysFB9xmJlZKQPiHMeQIUOira1tc4dhZrZFufvuux+LiBeN6zYgEkdbWxtLlizZ3GGYmW1RJNUdPcFdVWZmVooTh5mZleLEYWZmpThxmJlZKU4cZmZWihOHmZmV4sRhZmalOHGYmVkpThxmZlbKgLhz3KyVtlk3bJb1rjz7rZtlvWabwkccZmZWihOHmZmV4sRhZmalVJo4JE2UtFxSu6RZdZZL0vlp+VJJY3LL5kpaI+mBOvU+mtpdJumcKrfBzMw2VlnikDQIuACYBIwGpkoaXVNsEjAqvaYBF+aWXQZMrNPu64EpwMERcRBwXo8Hb2ZmDVV5xDEOaI+IFRGxHphP9oWfNwWYF5lFwGBJwwAi4g7gj3XaPQU4OyKeSeXWVLYFZmb2IlUmjuHAI7npjjSvbJlaBwD/JOlOSbdLOqxeIUnTJC2RtKSzs7Nk6GZm1kiViUN15kU3ytTaGtgFmACcBlwt6UXtRMSciBgbEWOHDn3Rkw/NzKybqkwcHcDI3PQIYFU3ytRr95rUvXUX8BwwZBNjNTOzgqpMHIuBUZL2kbQtcCywoKbMAuC4dHXVBGBtRKxu0e51wJEAkg4AtgUe69HIzcysocoSR0RsAGYCNwEPAVdHxDJJ0yVNT8UWAiuAduAi4CNd9SVdBfwcOFBSh6ST0qK5wL7pMt35wPER0ap7y8zMekilY1VFxEKy5JCfNzv3PoAZDepObTB/PfD+HgzTzMxK8J3jZmZWihOHmZmV4sRhZmalOHGYmVkpThxmZlaKE4eZmZXixGFmZqU4cZiZWSlOHGZmVooTh5mZleLEYWZmpThxmJlZKU4cZmZWihOHmZmV4sRhZmalOHGYmVkplSYOSRMlLZfULmlWneWSdH5avlTSmNyyuZLWpCf91Wv705JCkp83bmbWiypLHJIGARcAk4DRwFRJo2uKTQJGpdc04MLcssuAiQ3aHgm8Cfhdz0ZtZmatVHnEMQ5oj4gV6XGv84EpNWWmAPMiswgYLGkYQETcAfyxQdtfB04H/KxxM7NeVmXiGA48kpvuSPPKltmIpKOARyPivhblpklaImlJZ2dn8ajNzKypKhOH6syrPUIoUuaFwtIOwOeAL7RaeUTMiYixETF26NChrYqbmVlBVSaODmBkbnoEsKobZfL2A/YB7pO0MpW/R9IemxytmZkVUmXiWAyMkrSPpG2BY4EFNWUWAMelq6smAGsjYnWjBiPi/ojYLSLaIqKNLPGMiYjfV7QNZmZWo7LEEREbgJnATcBDwNURsUzSdEnTU7GFwAqgHbgI+EhXfUlXAT8HDpTUIemkqmI1M7Pitq6y8YhYSJYc8vNm594HMKNB3akF2m/bxBDNzKyklolD0m7A4cCewF+AB4AlEfFcxbGZmVkf1DBxSHo9MAvYFfgFsAbYHjga2E/S94H/iIgneiFOMzPrI5odcUwGTo6IF92dLWlr4G1kd2//oKLYzMysD2qYOCLitCbLNgDXVRGQmZn1bS2vqpK0u6RLJN2Ypkf7Ciczs4GryOW4l5FdUjssTf8K+HhF8ZiZWR9XJHEMiYirgefg+W6qZyuNyszM+qwiieNpSS8njSHVdYd3pVGZmVmfVeQGwE+SDQ2yn6SfAUOBd1UalZmZ9VktE0dE3CPpdcCBZKPZLo+Iv1UemZmZ9UlFhxwZB7Sl8mMkERHzKovKzMz6rCJDjvwX2XDm9/LCSfEAnDjMzAagIkccY4HRaUBCMzMb4IpcVfUA4AclmZkZUOyIYwjwoKS7gGe6ZkbEUZVFZWZmfVaRxHFW1UGYmdmWo2VXVUTcDvwS2DG9HkrzWpI0UdJySe2SZtVZLknnp+VLJY3JLZsraY2kB2rqnCvpl6n8tZIGF4nFzMx6RpFBDt8N3AUcA7wbuFNSyxsAJQ0CLgAmAaOBqZJG1xSbBIxKr2nAhblllwET6zR9C/D3EXEw2bhZn2kVi5mZ9ZwiXVWfAw6LiDUAkoYCPwK+36LeOKA9IlakevOBKcCDuTJTgHnpiq1FkgZLGhYRqyPiDklttY1GxM25yUX4LnYzs15V5KqqrbqSRvJ4wXrDgUdy0x1pXtkyzXwQ+J96CyRNk7RE0pLOzs4STZqZWTNFjjhulHQTcFWafg+wsEA91ZlXey9IkTL1G5c+B2wArqy3PCLmAHMAxo4d63tQzMx6SJGxqk6T9E7gcLIv+jkRcW2BtjuAkbnpEcCqbpR5EUnHkz269g2+MdHMrHcVGqsqIn5A+WeLLwZGSdoHeBQ4FnhvTZkFwMx0/mM8sDYiVjdrVNJE4AzgdRGxrmRMZma2iRomDklPknUbiY27jwREROzUrOGI2CBpJtnTAwcBcyNimaTpaflssi6vyUA7sA44Mbf+q4AjgCGSOoAzI+IS4JvAdsAtkgAWRcT0MhttZmbd1zBxRMSOm9p4RCyk5nxIShhd7wOY0aDu1Abz99/UuMzMrPuK3McxQdKOuemXSRpfbVhmZtZXFbms9kLgqdz0Oja+Uc/MzAaQIolD+SuXIuI5ij8AyszM+pkiiWOFpI9J2ia9TgVWVB2YmZn1TUUSx3TgH8kuqe0gu2x2WpVBmZlZ31XkBsA1ZPdgmJmZFTriMDMze54Th5mZldIwcaST4Eg6vPfCMTOzvq7ZEUfX8B/f6I1AzMxsy9Ds5PhDklYCQyUtzc3vGqvq4EojMzOzPqnZWFVTJe1BNkjhUb0XkpmZ9WVNL8eNiN8Dh0jaFjggzV4eEX+rPDIzM+uTWt7HIel1wDxgJVk31UhJx0fEHRXHZmZmfVCRMae+Brw5IpYDSDqA7DGyr64yMDMz65uK3MexTVfSAIiIXwHbVBeSmZn1ZUUSxxJJl0g6Ir0uAu4u0rikiZKWS2qXNKvOckk6Py1fKmlMbtlcSWskPVBTZ1dJt0j6dfq7S5FYzMysZxRJHKcAy4CPAacCD5INfNiUpEHABcAkYDQwVdLommKTgFHpNY2Nn/NxGTCxTtOzgFsjYhRwa5o2M7NeUmSQw2fIznN8rWTb44D2iFgBIGk+MIUs8XSZAsxLz/tYJGmwpGERsToi7pDUVqfdKWTPIge4HLgNOKNkbGZm1k1VjlU1HHgkN92R5pUtU2v3iFgNkP7uVq+QpGmSlkha0tnZWSpwMzNrrMon+anOvOhGmW6JiDnAHICxY8f2SJtWrbZZN2zuEMysgCqPODqAkbnpEcCqbpSp9QdJwwDS3zWbGKeZmZXQ8IhD0g9p8us/IloNQ7IYGCVpH7KnBx4LvLemzAJgZjr/MR5Y29UN1cQC4Hjg7PT3+hblzcysBzXrqjov/f1nYA/gijQ9lewu8qYiYoOkmWRjXQ0C5kbEMknT0/LZwEJgMtAOrOOFEXmRdBXZSfAhkjqAMyPiErKEcbWkk4DfAccU2lKzPmhzds+tPPutm23dtmVrNsjh7QCSvhwRr80t+qGkQsONRMRCsuSQnzc79z6AGQ3qTm0w/3HgDUXWb2ZmPa/IOY6hkvbtmkhdT0OrC8nMzPqyIldVfQK4TdKKNN0GfLiyiMzMrE8rcgPgjZJGAX+XZv0y3RRoZmYDUMuuKkk7AKcBMyPiPmAvSW+rPDIzM+uTipzjuBRYD/xDmu4AvlJZRGZm1qcVSRz7RcQ5wN8AIuIv1L/j28zMBoAiiWO9pJeQbgaUtB/gcxxmZgNUkauqzgRuJHtk7JXA4cAJVQZlZmZ9V5Grqm6RdA8wgayL6tSIeKzyyMzMrE8qOjru9sCfUvnRkoiIQnePm5lZ/9IycUj6d+A9ZE8BfC7NDsCJw8xsACpyxHE0cKBv+jMzMyh2VdUKYJuqAzEzsy1Ds+dxfIOsS2odcK+kW8ldhhsRH6s+PDMz62uadVUtSX/vJnt4kpmZWdPncVxeO0/SLsDIiFhaaVRmZtZnFRnk8DZJO0naFbgPuFTS14o0LmmipOWS2iXNqrNcks5Py5dKGtOqrqRDJS2SdK+kJZLGFdtUMzPrCUVOju8cEU+QPUL20oh4NfDGVpUkDQIuACYBo4GpkkbXFJsEjEqvacCFBeqeA3wxIg4FvpCmzcyslxRJHFtLGga8G/jvEm2PA9ojYkVErAfmA1NqykwB5kVmETA4ratZ3QB2Su93BlaViMnMzDZRkfs4vgTcBPw0Ihanx8j+ukC94cAjuekOYHyBMsNb1P04cJOk88gS3z/WW7mkaWRHMey1114FwjUzsyJaHnFExPci4uCI+EiaXhER7yzQdr2h16NgmWZ1TwE+EREjyR5re0mDuOdExNiIGDt0qB+RbmbWU5rdx3F6RJyTu59jIwXu4+gARuamR/DibqVGZbZtUvd44NT0/nvAxS3iMDOzHtSsq+qh9HdJkzLNLAZGSdoHeBQ4FnhvTZkFwExJ88m6otZGxGpJnU3qrgJeB9wGHEmxbjMzM+shze7j+GH6+6L7OYqIiA2SZpKdHxkEzI2IZZKmp+WzgYXAZKCd7A71E5vVTU2fDPw/SVsDfyWdxzAzs95RZHTcA4BPA2358hFxZKu6EbGQLDnk583OvQ9gRtG6af5PgVe3WreZmVWjyFVV3wNmk51LeLbacMzMrK8rkjg2RMSFlUdiZmZbhCI3AP5Q0kckDZO0a9er8sjMzKxPKnLEcXz6e1puXgD79nw4ZmbW17VMHBGxT28EYmZmW4ZmNwAeGRE/lvTP9ZZHxDXVhWVmZn1VsyOO1wI/Bt5eZ1kAThxmZgNQs8Txp/T3knTvhJmZWdOrqk5Mf8/vjUDMzGzL0HSsKkkrgaGS8o+KFdlN3wdXGpmZmfVJzcaqmippD7Lxoo7qvZDMzKwva3o5bkT8Hjikl2IxM7MtQJE7x83MzJ7nxGFmZqWUShyStpK0U1XBmJlZ39cycUj6jqSdJL0UeBBYLum0VvXMzKx/KnLEMToingCOJnuw0l7AB4o0LmmipOWS2iXNqrNcks5Py5dKGlOkrqSPpmXLJJ1TJBYzM+sZRUbH3UbSNmSJ45sR8TdJ0aqSpEHABcCbgA5gsaQFEfFgrtgkYFR6jQcuBMY3qyvp9cAU4OCIeEbSbkU31szMNl2RI45vAyuBlwJ3SNobeKJAvXFAe0SsiIj1wHyyL/y8KcC8yCwCBksa1qLuKcDZEfEMQESsKRCLmZn1kJaJIyLOj4jhETE5fcE/DLy+QNvDgUdy0x1pXpEyzeoeAPyTpDsl3S7psHorlzRN0hJJSzo7OwuEa2ZmRbTsqpK0HfBOoK2m/JdaVa0zr7aLq1GZZnW3BnYBJgCHAVdL2jciNmo7IuYAcwDGjh3bsmvNzMyKKXKO43pgLXA38EyJtjuAkbnpEcCqgmW2bVK3A7gmJYq7JD0HDAF8WGFm1guKJI4RETGxG20vBkZJ2gd4FDgWeG9NmQXATEnzyU6Or42I1ZI6m9S9DjgSuE3SAWRJ5rFuxGdmZt1QJHH8n6RXRsT9ZRqOiA2SZpINkjgImBsRyyRNT8tnk13eOxloB9aRhnJvVDc1PReYK+kBYD1wfG03lZmZVadI4ngNcIKk35J1VRUeVj0iFpIlh/y82bn3AcwoWjfNXw+8v0DcZmZWgSKJY1LlUZiZ2RajyOW4D5OdqD4yvV9XpJ6ZmfVPRcaqOhM4A/hMmrUNcEWVQZmZWd9V5MjhHWRPAHwaICJWATtWGZSZmfVdRRLH+nQSOwDSKLlmZjZAFUkcV0v6Ntk4UicDPwIuqjYsMzPrq1peVRUR50l6E9nAhgcCX4iIWyqPzMzM+qQil+OSEoWThZmZNe6qknRS/kl/kjokPSHpSUmn9E54ZmbW1zQ7xzGdbHiPLp0RsRMwFJhaaVRmZtZnNUscW0XE47np7wFExF+Bl1QalZmZ9VnNEsfO+YmI+CqApK2Al1cZlJmZ9V3NEsfNkr5SZ/6XgJsrisfMzPq4ZldVnQZcLKkduC/NOwRYAnyo6sDMzKxvapg4IuJpYKqkfYGD0uwHI+I3vRKZmZn1SQ0Th6S2iFgZESuAFXWWCxgeER1VBmhmZn1Ls3Mc50r6gaTjJB0kaTdJe0k6UtKXgZ8Br2jWuKSJkpZLapc0q85ySTo/LV8qaUyJup+WFJKGlNheMzPbRM26qo6RNBp4H/BBYBjwF+Ah4AbgX9OluXVJGgRcALwJ6AAWS1oQEQ/mik0CRqXXeOBCYHyrupJGpmW/69ZWm5lZtzUdciR9UX+um22PA9pTVxeS5gNTgHzimALMS6PvLpI0WNIwoK1F3a8DpwPXdzM2MzPrpiIPctpe0iclXZO6rj4hafsCbQ8HHslNd6R5Rco0rCvpKODRiLiPJiRNk7RE0pLOzs4C4ZqZWRFFhlWfR3ZV1TeAb5Kd1/ivAvVUZ14ULFN3vqQdyI6AvtBq5RExJyLGRsTYoUOHtgzWzMyKKTI67oERcUhu+n8lNf21n3SQPau8ywhgVcEy2zaYvx+wD3BfdlEXI4B7JI2LiN8XiMnMzDZRkSOOX0ia0DUhaTzZFVWtLAZGSdpH0rbAscCCmjILgOPS1VUTgLURsbpR3Yi4PyJ2i4i2iGgjSzxjnDTMzHpPkSOO8WRf7l1XMO0FPCTpfiAi4uB6lSJig6SZwE3AIGBuRCyTND0tnw0sBCYD7cA64MRmdbu7kWZm1nOKJI6J3W08IhaSJYf8vNm59wHMKFq3Tpm27sZmZmbdU+TRsQ/3RiBmZrZlKHKOw8zM7HlOHGZmVooTh5mZleLEYWZmpThxmJlZKUUuxzWzfqht1g2bZb0rz37rZlmv9RwfcZiZWSlOHGZmVooTh5mZleLEYWZmpThxmJlZKU4cZmZWihOHmZmV4sRhZmalOHGYmVkplSYOSRMlLZfULmlWneWSdH5avlTSmFZ1JZ0r6Zep/LWSBle5DWZmtrHKEoekQcAFwCRgNDBV0uiaYpOAUek1DbiwQN1bgL9Pj6z9FfCZqrbBzMxerMojjnFAe0SsiIj1wHxgSk2ZKcC8yCwCBksa1qxuRNwcERtS/UXAiAq3wczMalQ5yOFw4JHcdAcwvkCZ4QXrAnwQ+G69lUuaRnYUw1577VUm7gFvcw1+Z2ZbhiqPOFRnXhQs07KupM8BG4Ar6608IuZExNiIGDt06NAC4ZqZWRFVHnF0ACNz0yOAVQXLbNusrqTjgbcBb4iI2mRkZmYVqvKIYzEwStI+krYFjgUW1JRZAByXrq6aAKyNiNXN6kqaCJwBHBUR6yqM38zM6qjsiCMiNkiaCdwEDALmRsQySdPT8tnAQmAy0A6sA05sVjc1/U1gO+AWSQCLImJ6VdthZmYbq/QJgBGxkCw55OfNzr0PYEbRumn+/j0cppmZleA7x83MrBQnDjMzK8WJw8zMSnHiMDOzUpw4zMysFCcOMzMrxYnDzMxKqfQ+Dts0HmzQzPoiJw4z61Wb8wfRyrPfutnW3Z+4q8rMzErxEUcL7i4yM9uYjzjMzKwUJw4zMyvFicPMzEpx4jAzs1J8ctzMBozNdbFLf7sMuNIjDkkTJS2X1C5pVp3lknR+Wr5U0phWdSXtKukWSb9Of3epchvMzGxjlSUOSYOAC4BJwGhgqqTRNcUmAaPSaxpwYYG6s4BbI2IUcGuaNjOzXlJlV9U4oD0iVgBImg9MAR7MlZkCzEuPkF0kabCkYUBbk7pTgCNS/cuB24AzKtwOM7NN0t/ulq8ycQwHHslNdwDjC5QZ3qLu7hGxGiAiVkvard7KJU0jO4oBeErS8u5sBDAEeKybdfsj748XeF+8wPtiY31mf+jfN6n63vVmVpk4VGdeFCxTpG5TETEHmFOmTj2SlkTE2E1tp7/w/niB98ULvC821t/3R5UnxzuAkbnpEcCqgmWa1f1D6s4i/V3TgzGbmVkLVSaOxcAoSftI2hY4FlhQU2YBcFy6umoCsDZ1QzWruwA4Pr0/Hri+wm0wM7MalXVVRcQGSTOBm4BBwNyIWCZpelo+G1gITAbagXXAic3qpqbPBq6WdBLwO+CYqrYh2eTurn7G++MF3hcv8L7YWL/eH8ouaDIzMyvGQ46YmVkpThxmZlaKE0cTrYZM6e8krZR0v6R7JS1J8wbEkC+S5kpaI+mB3LyG2y7pM+lzslzSWzZP1NVpsD/OkvRo+nzcK2lyblm/3R+SRkr6X0kPSVom6dQ0f8B8Ppw4Gig4ZMpA8PqIODR3TfpAGfLlMmBizby6254+F8cCB6U630qfn/7kMl68PwC+nj4fh0bEQhgQ+2MD8KmIeAUwAZiRtnnAfD6cOBp7fsiUiFgPdA17MtBNIRvqhfT36M0XSnUi4g7gjzWzG237FGB+RDwTEb8lu0pwXG/E2Vsa7I9G+vX+iIjVEXFPev8k8BDZaBcD5vPhxNFYo+FQBpIAbpZ0dxrCBWqGfAHqDvnSTzXa9oH8WZmZRraem+uaGTD7Q1Ib8CrgTgbQ58OJo7FNHvakHzg8IsaQddfNkPTazR1QHzVQPysXAvsBhwKrgf9I8wfE/pD0MuAHwMcj4olmRevM26L3hxNHY0WGTOnXImJV+rsGuJbs8HogD/nSaNsH5GclIv4QEc9GxHPARbzQ/dLv94ekbciSxpURcU2aPWA+H04cjRUZMqXfkvRSSTt2vQfeDDzAwB7ypdG2LwCOlbSdpH3Ini9z12aIr1d1fUkm7yD7fEA/3x+SBFwCPBQRX8stGjCfDz86toEWw54MBLsD12b/R9ga+E5E3ChpMb075MtmIekqsue+DJHUAZxJg+Fu0lA6V5M9L2YDMCMint0sgVekwf44QtKhZN0uK4EPw4DYH4cDHwDul3RvmvdZBtDnw0OOmJlZKe6qMjOzUpw4zMysFCcOMzMrxYnDzMxKceIwM7NSnDhsiyBpd0nfkbQiDYHyc0nvqHB920n6URr19T2SLm41yKWk6ZKOa7L8LEmf3oSYTpD0zRLlN9qGAuXb8qPfmjXi+zisz0s3XF0HXB4R703z9gaOqnC1rwK2iYhD0/R3W1VIj0PuS2q3waxH+IjDtgRHAuvzX8wR8XBEfAOyIfAlnStpcRpw78Np/hGSbpP0fUm/lHRlSkJIOlvSg6n8efmVSdoNuAI4NP1a3y+1MzYtf0rSv0q6T9IiSbun+c8fUUj6WK79+bnmR6e2Vkj6WG6d75d0V1rft7uG3ZZ0oqRfSbqd7MazF1H2HIjr0roWSTq43jbU1Nk/HY3cJ+meOsu3l3Spsuex/ELS69P8EyRdI+lGZc+dOCdX583pSPAeSd9TNpaT9UNOHLYlOAi4p8nyk4C1EXEYcBhwchraAbJf3R8ne6bKvsDhknYlGyLjoIg4GPhKvrE0NteHgJ+k50z8pmZ9LwUWRcQhwB3AyXVimgW8KrU/PTf/74C3kI3rdKakbSS9AngP2aCShwLPAu9LQ3p8kSxhvCltQz1fBH6R1vVZYF6BbbgSuCBtwz+SDVKYNyPti1cCU4HLJW2flh2a4n0l8B5lDzYaAnweeGMaGHMJ8MkG8doWzl1VtsWRdAHwGrKjkMPIxtE6WNK7UpGdycYDWg/cFREdqd69QBuwCPgrcLGkG4D/LhnC+lydu8m+1GstBa6UdB1ZN1uXGyLiGeAZSWvIhnZ5A/BqYHE6IHoJ2QB544HbIqIzxf9d4IA663oN8E6AiPixpJdL2rlR8MrGIBseEdemOn9N82vb/EZa/ktJD+fWfWtErE11HgT2BgaTJbafpXa2BX7eKAbbsjlx2JZgGemLESAiZqRfuEvSLAEfjYib8pUkHQE8k5v1LLB1GodsHNkX9rHATLLusKL+Fi+M1fMs9f8fvRV4Ldl5mH+RdFCa/6J4UvyXR8RnauI/mmLDb5cdtrte+TJlGm3DLRExtUDbtoVzV5VtCX4MbC/plNy8HXLvbwJOUTbUNZIOUDaib12p733n9KjTj5N1vfQYSVsBIyPif4HTyX6NN+vvvxV4Vzov0XXOYm+yhwMdkY4gtqHxgJJ3AO9LdY8AHmv2fIi0rCMlpq6rr3aoKZZv8wBgL2B5k21YRNYNuH+qs0OqZ/2Qjzisz4uISF9yX5d0OtAJPA2ckYpcTNYFdU86+d1J80fa7ghcn/rsBXyih0MeBFyRuotE9lzuP9d0BT0vIh6U9Hmypy1uBfyNbATVRZLOIuvyWU12nqfes6rPAi6VtBRYxwtDezfzAeDbkr6U1ncM8Fxu+beA2ZLuJxvR9YSIeKbJNnRKOgG4StJ2afbngV8ViMW2MB4d18zMSnFXlZmZleLEYWZmpThxmJlZKU4cZmZWihOHmZmV4sRhZmalOHGYmVkp/x8FzwtBvaCMBQAAAABJRU5ErkJggg==\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, ax = plt.subplots(1, 1)\n",
     "n, bins, patches = ax.hist(df.gen, cumulative=False, density=True)\n",
@@ -190,10 +401,35 @@
   },
   {
    "cell_type": "code",
-   "execution_count": null,
+   "execution_count": 38,
    "id": "f71fe3de-e44e-4d9a-b9e2-246f8b16b65d",
-   "metadata": {},
-   "outputs": [],
+   "metadata": {
+    "hidden": true
+   },
+   "outputs": [
+    {
+     "data": {
+      "text/plain": [
+       "Text(0.5, 1.0, 'CDF')"
+      ]
+     },
+     "execution_count": 38,
+     "metadata": {},
+     "output_type": "execute_result"
+    },
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAYIAAAEWCAYAAABrDZDcAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAAAbIElEQVR4nO3de7gcVZ3u8e9LuEQUiJjIIBASMeqgg6gR9MhowKMDDoo4OgKOCKNEEFDUcYjnYZRxnjnHC94GgRgRL0cRceQqUVQu6ghoEgaBgHAyQSQEBWTkqkCS9/xRtUmn6d27srOrmnS9n+fpZ1etuvSv6+m9f7vWqrWWbBMREe21yaADiIiIwUoiiIhouSSCiIiWSyKIiGi5JIKIiJZLIoiIaLkkgoiIlksiiKhA0iGSFkt6QNIdkr4naS9JJ0p6VNL95etmSZ+XtH3HsXMkrSmPHXldOMjPE9EpiSBiDJLeD3wW+N/AdsB04FTggHKXb9neCtgWOBD4M2BJZzIAVtp+SsfrdY19gIgxJBFE9CFpG+CjwNG2z7H9oO1HbV9o+4Od+5blS4G3AHcBHxhAyBHrLYkgor+XAZOBc6seYHs1cD7wl3UFFTGRkggi+nsacLftVet53EqKqqIRz5D0h47X305ciBEbZtNBBxDxBPd7YKqkTdczGewA3NOxvtL2jhMbWsTEyB1BRH9XAn8C3lD1AEmbAK8DflpTTBETKncEEX3YvlfSh4FTJK0CfgA8CvxPYG/goZF9JW0GPAs4keLJoU83HnDEOOSOIGIMtj8NvB84geJpoNuAY4Dzyl3eIukB4A/ABRTVSS+2vbLxYCPGQZmYJiKi3XJHEBHRckkEEREtl0QQEdFySQQRES230T0+OnXqVM+YMWPQYUREbFSWLFlyt+1pvbZtdIlgxowZLF68eNBhRERsVCTdOtq2VA1FRLRcEkFERMslEUREtFwSQUREyyURRES0XBJBRETL1ZYIJJ0h6U5J14+yXZL+TdIySddKelFdsURExOjqvCP4CrBvn+37AbPK11zgtBpjiYiIUdSWCGz/hHWn6ut2APA1F64Cpkjavq54IiKit0H2LN6BYoKPESvKsju6d5Q0l+KugenTpzcSXEQ8sc2Yd9GgQ2jcrz/217Wcd5CJQD3Kes6SY3sBsABg9uzZmUkn4gmijX+Mh9EgnxpaAezUsb4jkKn9IiIaNshEcAFwaPn00EuBe20/rlooIiLqVVvVkKRvAnOAqZJWAB8BNgOwPR9YCLwWWAY8BBxeVywRETG62hKB7YPH2G7g6LreP6JNUlcfGyI9iyMiWi6JICKi5ZIIIiJaLokgIqLlkggiIlouiSAiouWSCCIiWi6JICKi5ZIIIiJaLokgIqLlkggiIlouiSAiouXGHHRO0hbA3wAzOve3/dH6woqIiKZUGX30fOBeYAnwcL3hRERE06okgh1t71t7JBFDIMNBx8aoShvBFZL+ovZIIiJiIKrcEewFHCbpFoqqIVHMK7NbrZFFREQjqiSC/WqPIiIiBmbMqiHbtwJTgNeVryllWUREDIExE4Gk9wLfAJ5evr4u6di6A4uIiGZUqRp6B7Cn7QcBJH0cuBI4uc7AIiKiGVWeGhKwumN9dVkWERFDoModwZeBn0s6t1x/A/Cl2iKKiIhGjZkIbH9a0uUUj5EKONz2f9YdWERENGPURCBpa9v3SdoW+HX5Gtm2re176g8vIiLq1u+O4Exgf4oxhtxRrnL9mTXGFRERDRk1Edjev/w5s7lwIiKiaVX6EVxSpSwiIjZO/doIJgNbAlMlPZW1j4xuDTyjgdgiIqIB/doI3gUcR/FHfwlrE8F9wCn1hhUREU3p10bwOeBzko61nV7EERFDqkrP4jWSpoysSHqqpHfXF1JERDSpSiI4wvYfRlZs/zdwRJWTS9pX0k2Slkma12P7NpIulPRLSUslHV458oiImBBVEsEmkh4bW0jSJGDzsQ4q9zuFYj6DXYGDJe3atdvRwA22XwDMAT4lacxzR0TExKmSCC4Gzpb0Kkn7AN8Evl/huD2AZbaX234EOAs4oGsfA1uVieYpwD3AqsrRR0TEBqsy6NzxFE8QHUXx5NAPgNMrHLcDcFvH+gpgz659Pg9cAKwEtgLeYntN94kkzQXmAkyfPr3CW0dERFVVBp1bA5xWvtZHr6Gq3bX+V8A1wD7ALsAPJf3U9n1dMSwAFgDMnj27+xwREbEBqvQsfrmkH0q6WdJySbdIWl7h3CuAnTrWd6T4z7/T4cA5LiwDbgGeWzX4iIjYcFWqhr4EvI+iU9nqMfbttAiYJWkmcDtwEHBI1z6/AV4F/FTSdsBzgCpJJiIiJkiVRHCv7e+t74ltr5J0DEVj8yTgDNtLJR1Zbp8P/AvwFUnXUVQlHW/77vV9r4iIGL8qieAySZ8EzgEeHim0ffVYB9peCCzsKpvfsbwSeE3laCMiYsJVSQQjT/rM7igzRQNvRERs5Ko8NbR3E4FERMRgjJkIJH24V7ntj058OBER0bQqVUMPdixPppi+8sZ6womIiKZVqRr6VOe6pJMoegNHRMQQqDLWULctycT1ERFDo0obwXWsHRpiEjANSPtARMSQqNJGsH/H8irgd7YzQmhExJAYtWpI0g8AbN8KHGL7Vtu3JwlERAyXfm0E0zqW31x3IBERMRj9EkGGe46IaIF+bQTPlHQBxWBwI8uPsf36WiOLiIhG9EsEndNKnlR3IBERMRijJgLbP24ykIiIGIzxdCiLiIghkkQQEdFySQQRES1XZYiJZwMfBHbu3N92JqaJiBgCVYaY+DYwH/gi6zd5fcRAzJh30aBDiNioVEkEq2yfVnskERExEFXaCC6U9G5J20vaduRVe2QREdGIKncEby9/frCjzGROgoiIoVBlhrKZTQQSERGDUeWpoc2Ao4BXlEWXA1+w/WiNcUVEREOqVA2dBmwGnFquv60se2ddQUVERHOqJIKX2H5Bx/qlkn5ZV0AREdGsKk8NrZa0y8iKpGeS/gQREUOjyh3BB4HLJC2nmJtgZ+DwWqOKiIjGVHlq6BJJs4DnUCSCX9l+uPbIIiKiEaMmAkn72L5U0hu7Nu0iCdvn1BxbREQ0oN8dwSuBS4HX9dhmIIkgImII9Juh7CPl4kdt39K5TVI6mUVEDIkqTw19p0fZv1c5uaR9Jd0kaZmkeaPsM0fSNZKWSsr0mBERDevXRvBc4HnANl3tBFsDk8c6saRJwCnAq4EVwCJJF9i+oWOfKRQd1fa1/RtJTx/Xp4iIiHHr10bwHGB/YArrthPcDxxR4dx7AMtsLweQdBZwAHBDxz6HAOfY/g2A7TsrRx4REROiXxvB+cD5kl5m+8pxnHsH4LaO9RXAnl37PBvYTNLlwFbA52x/bRzvFRER41SlQ9lcSY+7A7D992Mcpx5l7vH+LwZeBTwJuFLSVbZvXudE0lxgLsD06dMrhBwREVVVSQTf7VieDBwIrKxw3Apgp471HXsctwK42/aDwIOSfgK8AFgnEdheACwAmD17dncyiYiIDVClZ/E6Tw1J+ibwowrnXgTMKh81vR04iKJNoNP5wOclbQpsTlF19JkK546IiAlS5Y6g2yxgzPoZ26skHQNcDEwCzrC9VNKR5fb5tm+U9H3gWmANcLrt68cRU0REjFOViWnup6jbV/nzt8DxVU5ueyGwsKtsftf6J4FPVow3IiImWJWqoa2aCCQiIgajUtVQ2aFsL4o7gp/aPq/OoCIiojljDjEh6VTgSOA64HrgSEmn1B1YREQ0o8odwSuB59s2gKSvUiSFiIgYAlUGnbuJdZ8S2oniKZ+IiBgC/Qadu5CiTWAb4EZJvyjX9wSuaCa8iIioW7+qoZMaiyIiIgam36BzmRsgIqIF+lUN/YftvTo6lD22CbDtrWuPLiIiatfvjmCv8mc6lEVEDLG+Tw1J2kRSxv6JiBhifROB7TXALyVlEoCIiCFVpUPZ9sDS8vHRB0cKbb++tqgiIqIxVRLBP9ceRUREDEyVRPBa2+sMOy3p40AeL42IGAJVhph4dY+y/SY6kIiIGIx+/QiOAt4N7CKpc2yhrYCf1R1YREQ0o1/V0JnA94D/A8zrKL/f9j21RhUREY0ZtWrI9r22fw2cAPzW9q3ATODvJE1pJryIiKhblTaC7wCrJT0L+BJFMjiz1qgiIqIxVRLBGturgDcCn7X9Poq+BRERMQSqJIJHJR0MHAp8tyzbrL6QIiKiSVUSweHAy4B/tX2LpJnA1+sNKyIimjJmhzLbNwDv6Vi/BfhYnUFFRERz+vUjONv230q6jnXnIwDA9m61RhYREY3od0fw3vLn/k0EEhERg9FvYpo7ysV7gVnl8s227609qoiIaEy/qqHNgQXAG4BbKKao3FnSucCRth9pJMKIiKhVv6eGTqB4THQn2y+0vTswnSJ5/FMDsUVERAP6JYI3AkfYvn+koFx+N3Bg3YFFREQz+iWCNbYf6i60/QA9niKKiIiNU7+nhizpqRRtA93W1BRPREQ0rF8i2AZYQu9EkDuCiIgh0W8Y6hm2n2l7Zo/XM6ucXNK+km6StEzSvD77vUTSaklvGs+HiIiI8asy1tC4SJoEnEIxreWuwMGSdh1lv48DF9cVS0REjK62RADsASyzvbzsc3AWcECP/Y6lmPPgzhpjiYiIUdSZCHYAbutYX1GWPUbSDhSPos7vdyJJcyUtlrT4rrvumvBAIyLarFIikLSXpMPL5WnlUNRjHtajrLuR+bPA8bZX9zuR7QW2Z9uePW3atCohR0RERWMOQy3pI8Bs4DnAlyl6G38dePkYh64AdupY3xFY2bXPbOAsSQBTgddKWmX7vCrBR0TEhhszEVBU3bwQuBrA9kpJW1U4bhEwq7x7uB04CDikcwfbj91ZSPoK8N0kgYiIZlVJBI/YtiQDSHpylRPbXiXpGIqngSYBZ9heKunIcnvfdoGIiGhGlURwtqQvAFMkHQH8PfDFKie3vRBY2FXWMwHYPqzKOSMiYmJVmaryJEmvBu6jaCf4sO0f1h5ZREQ0okpj8fuAb+ePf0TEcKry+OjWwMWSfirpaEnb1R1UREQ0Z8xEYPufbT8POBp4BvBjST+qPbKIiGjE+vQsvhP4LfB74On1hBMREU0bMxFIOkrS5cAlFJ2+jrC9W92BRUREM6o8ProzcJzta2qOJSIiBmDURCBpa9v3AZ8o17ft3G77nppji4iIBvS7IzgT2J9iljKz7iByBipNThMREU9soyYC2/uXP6uMNBoRERupKo3Fl1Qpi4iIjVO/NoLJwJbAVElPZW3V0NYU/QkiImII9GsjeBdwHMUf/SWsTQT3UcxFHBERQ6BfG8HngM9JOtb2yQ3GFENixryLBh1CRFRQZfTRkyU9H9gVmNxR/rU6A4uIiGZUnapyDkUiWAjsB/wHkEQQETEEqow19CbgVcBvbR8OvADYotaoIiKiMVUSwR9trwFWSdqaYvC5dCaLiBgSVcYaWixpCsX0lEuAB4Bf1BlUREQ0p0pj8bvLxfmSvg9sbfvaesOKiIim9OtQ9qJ+22xfXU9IERHRpH53BJ/qs83APhMcS0REDEC/DmV7NxlIREQMRpV+BIf2Kk+HsoiI4VDlqaGXdCxPpuhTcDXpUBYRMRSqPDV0bOe6pG2A/1tbRBER0agqHcq6PQTMmuhAIiJiMKq0EVxI8ZQQFIljV+DsOoOKiIjmVGkjOKljeRVwq+0VNcUTERENq9JG8GOAcpyhTcvlbW3fU3NsERHRgCpVQ3OBfwH+CKyhmKnMZOC5iIihUKVq6IPA82zfXXcwERHRvCpPDf0XxZNC603SvpJukrRM0rwe298q6drydYWkF4znfSIiYvyq3BF8CLhC0s+Bh0cKbb+n30GSJlFMcv9qYAWwSNIFtm/o2O0W4JW2/1vSfsACYM/1/AwREbEBqiSCLwCXAtdRtBFUtQewzPZyAElnAQcAjyUC21d07H8VsON6nD8iIiZAlUSwyvb7x3HuHYDbOtZX0P+//XcA3+u1oWywngswffr0cYQSERGjqdJGcJmkuZK2l7TtyKvCcepR5h5lSNqbIhEc32u77QW2Z9uePW3atApvHRERVVW5Izik/PmhjrIqj4+uAHbqWN8RWNm9k6TdgNOB/Wz/vkI8ERExgap0KJs5znMvAmZJmgncDhzE2qQCgKTpwDnA22zfPM73iYiIDVDbfAS2V0k6BrgYmAScYXuppCPL7fOBDwNPA06VBEV7xOz1+wgREbEhap2PwPZCYGFX2fyO5XcC76wUaURE1CLzEUREtFzmI4iIaLnMRxAR0XKZjyAiouVGTQSSngVsNzIfQUf5X0rawvZ/1R5dRETUrl8bwWeB+3uU/7HcFhERQ6BfIphh+9ruQtuLgRm1RRQREY3qlwgm99n2pIkOJCIiBqNfIlgk6YjuQknvAJbUF1JERDSp31NDxwHnSnora//wzwY2Bw6sOa6IiGjIqInA9u+A/1EOEf38svgi25c2EllERDSiyhATlwGXNRBLREQMwHiGmIiIiCGSRBAR0XJJBBERLZdEEBHRckkEEREtl0QQEdFyVYahjo3YjHkXDTqEiHiCyx1BRETLJRFERLRcEkFERMslEUREtFwSQUREyyURRES0XBJBRETLJRFERLRcEkFERMulZ3FD0sM3Ip6ockcQEdFySQQRES2XRBAR0XKtaiNIPX1ExOPVekcgaV9JN0laJmlej+2S9G/l9mslvajOeCIi4vFqSwSSJgGnAPsBuwIHS9q1a7f9gFnlay5wWl3xREREb3XeEewBLLO93PYjwFnAAV37HAB8zYWrgCmStq8xpoiI6FJnG8EOwG0d6yuAPSvsswNwR+dOkuZS3DEAPCDppnHGNBW4e5zHDqNcj7VyLdbKtVjXE+Z66OMbdPjOo22oMxGoR5nHsQ+2FwALNjggabHt2Rt6nmGR67FWrsVauRbrasP1qLNqaAWwU8f6jsDKcewTERE1qjMRLAJmSZopaXPgIOCCrn0uAA4tnx56KXCv7Tu6TxQREfWprWrI9ipJxwAXA5OAM2wvlXRkuX0+sBB4LbAMeAg4vK54ShtcvTRkcj3WyrVYK9diXUN/PWQ/rko+IiJaJENMRES0XBJBRETLtSYRjDXcxbCT9GtJ10m6RtLismxbST+U9P/Kn08ddJx1kXSGpDslXd9RNurnl/Sh8rtyk6S/GkzU9RjlWpwo6fby+3GNpNd2bBvma7GTpMsk3ShpqaT3luWt+m60IhFUHO6iDfa2vXvHM9HzgEtszwIuKdeH1VeAfbvKen7+8rtxEPC88phTy+/QsPgKj78WAJ8pvx+7214IrbgWq4AP2P5z4KXA0eVnbtV3oxWJgGrDXbTRAcBXy+WvAm8YXCj1sv0T4J6u4tE+/wHAWbYftn0LxVNtezQRZxNGuRajGfZrcYftq8vl+4EbKUY3aNV3oy2JYLShLNrEwA8kLSmH7ADYbqTfRvnz6QOLbjBG+/xt/b4cU44CfEZHVUhrroWkGcALgZ/Tsu9GWxJBpaEshtzLbb+IonrsaEmvGHRAT2Bt/L6cBuwC7E4x1tenyvJWXAtJTwG+Axxn+75+u/Yo2+ivR1sSQeuHsrC9svx5J3Auxe3s70ZGey1/3jm4CAditM/fuu+L7d/ZXm17DfBF1lZ3DP21kLQZRRL4hu1zyuJWfTfakgiqDHcxtCQ9WdJWI8vAa4DrKa7B28vd3g6cP5gIB2a0z38BcJCkLSTNpJgv4xcDiK8xXcO/H0jx/YAhvxaSBHwJuNH2pzs2teq70YqpKkcb7mLAYTVpO+Dc4jvPpsCZtr8vaRFwtqR3AL8B3jzAGGsl6ZvAHGCqpBXAR4CP0ePzl0OhnA3cQPFUydG2Vw8k8BqMci3mSNqdoprj18C7YPivBfBy4G3AdZKuKcv+Fy37bmSIiYiIlmtL1VBERIwiiSAiouWSCCIiWi6JICKi5ZIIIiJaLokgGidpO0lnSlpeDnlxpaQDa3y/LST9qBxV8y2STh9r0EFJR0o6tM/2EyX9wwbEdJikz6/H/ut8hgr7z+gcXTSin1b0I4gnjrIDz3nAV20fUpbtDLy+xrd9IbCZ7d3L9W+NdUA5leoTSfdniJgwuSOIpu0DPNL5h9b2rbZPhmLIcEmflLSoHADtXWX5HEmXS/p3Sb+S9I0yqSDpY5JuKPc/qfPNJD0d+Dqwe/nf9C7leWaX2x+Q9K+SfinpKknbleWP/ccv6T0d5z+r4/S7ludaLuk9He/5d5J+Ub7fF0aGKZZ0uKSbJf2YoiPT46gYB/+88r2ukrRbr8/QdcyzyruFX0q6usf2yZK+rGI+iv+UtHdZfpikcyR9X8W4+5/oOOY15Z3a1ZK+rWIsnhhWtvPKq7EX8B6Kce9H2z4XOKFc3gJYDMyk6Al7L8XYLpsAVwJ7AdsCN7G2c+SUHuecA3y3Y/1yYHa5bOB15fInOt77ROAfyuWVwBad5y+3X1HGOBX4PbAZ8OfAhRT/vQOcChwKbE/RQ3UasDnwM+DzPWI9GfhIubwPcE2vz9B1zM+BA8vlycCWwAzg+rLsA8CXy+XnlnFMBg4DlgPblOu3UoyjMxX4CfDk8pjjgQ8P+ruTV32vVA3FQEk6heIP+iO2X0IxDtJukt5U7rINxXgujwC/sL2iPO4aij92VwF/Ak6XdBHw3fUM4ZGOY5YAr+6xz7XANySdR1GtNeIi2w8DD0u6k2Ioj1cBLwYWlTcsT6IYsGxP4HLbd5Xxfwt4do/32gv4GwDbl0p6mqRtRgtexRhSO9g+tzzmT2V59zlPLrf/StKtHe99ie17y2NuAHYGplBM4PSz8jybUyTeGFJJBNG0pZR/6ABsHy1pKsV//lAM83us7Ys7D5I0B3i4o2g1sKmLcaT2oPgDfBBwDMV/0lU9antknJXV9P6d+GvgFRTtGP8k6Xll+ePiKeP/qu0PdcX/BqoNV7y+wxz32n999hntM/zQ9sEVzh1DIG0E0bRLgcmSjuoo27Jj+WLgKBVDAyPp2SpGTO2prLvexsXUisdRjKc/YSRtAuxk+zLgHyn+W+5XX34J8KayXn+kzn9niuqbOeV/+Jsx+gB/PwHeWh47B7jbfcbHL7etKBPNyNNFW3bt1nnOZwPTKarTRnMV8HJJzyqP2bI8LoZU7giiUbZd/tH6jKR/BO4CHqSohwY4naLK5+qyMfgu+k+huRVwvqTJFP/Jvm+CQ54EfL2snhFF+8YfuqpeHmP7BkknUMwGtwnwKMUIlVdJOpGiiuUO4Ory3N1OBL4s6VrgIdYOhdzP24AvSPpo+X5vBtZ0bD8VmC/pOooRMw+z/XCfz3CXpMOAb0raoiw+Abi5QiyxEcrooxERLZeqoYiIlksiiIhouSSCiIiWSyKIiGi5JIKIiJZLIoiIaLkkgoiIlvv/lXiXiZZy9r0AAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 432x288 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
    "source": [
     "fig, ax = plt.subplots(1, 1)\n",
     "n, bins, patches = ax.hist(df.gen, cumulative=True, density=True)\n",
@@ -201,13 +437,68 @@
     "ax.set_ylabel(\"Cumulative Distribution Function\")\n",
     "ax.set_title(\"CDF\")"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "id": "1bfc1958",
+   "metadata": {},
+   "source": [
+    "## Distribution of traj lengths"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 9,
+   "id": "b888789d",
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "wu_length = 10\n",
+    "traj_lengths_ns = df['gen'].values*wu_length"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 32,
+   "id": "5003b509",
+   "metadata": {},
+   "outputs": [
+    {
+     "data": {
+      "image/png": "iVBORw0KGgoAAAANSUhEUgAAAoUAAAJ/CAYAAAAOIKmrAAAAOXRFWHRTb2Z0d2FyZQBNYXRwbG90bGliIHZlcnNpb24zLjQuMiwgaHR0cHM6Ly9tYXRwbG90bGliLm9yZy8rg+JYAAAACXBIWXMAAAsTAAALEwEAmpwYAABBt0lEQVR4nO3de9zlc73//8cLCQ0pBjEyQu1NOYRNKZR0lAgdVFJ2dg7V3p2Mdkn1K9M5O4e23UEl+1sIoROKFJVB7SJFGYfJIKdm5DCZ1++Pz3s1y3KtdV3rvK41j/vt9rl9rvX5vN/v9b7W+7rmes7n8P5EZiJJkqTl2wrD7oAkSZKGz1AoSZIkQ6EkSZIMhZIkScJQKEmSJAyFkiRJwlAoSZIkDIWSJEnCUCiNpaj8c0S8MSKOj4jLI+LBiMiyzO6gzd0j4pSI+FNE3B8Rd0XE1RFxckS8us221o6Iv9T15+R+9SMiZte9z2TL2u18H93q9HOIiD0i4tyIuDUiHoiIGyPiSxHxjDbfv+sx7fHPxSoRsVdEnBAR8yLi7ohYUj6jiyPiXRGxxiRtjOx4S6MufKKJNH5K6LuhRZGNM3P+FNt6HPBVYJ8WxW7MzNlt9O8U4HV1m76amQf2ox9T+CzqzczMv0yxbNc6/BxOBN7aZPeDwMGZ+bVJ2uh6TPv0c/FXYPVJit0C7JOZv2zSxmxGdLylUeeRQmn8LQDOBC5pt2JEPBb4LtUf/qXAScBzgHXL8lzgk+U9ptrm7lRBaKp/uHvZj5dShY4JlwEHwk4+h/eyLBCeBWwLrAO8CPgt8FjgSxGxU4s2uv4s+/FzUawOPAR8C9gf2Ax4IvB0YC7wd2AW8P2I2GAK7Y3MeEvTQma6uLiM2UL1R+8VwHp1244Gsiyzp9jOR0v5vwN796BfqwJ/LG2+pK4/J/erH8DsuvfZddhj0+nnAMwEFpVyP6Cc6anbvxawsOz/eT/HtNc/F3XtHl//MzvB/v3rPqsTpst4u7hMl8UjhdIYysxFmXl2Zi7stI2IWB94T3l5Qmae2YOufQh4CnB6Zn5viP0YtrY/B+CNwIzy9ZGZ+YhrfzLzTuAT5eUOEfHMxgZ68Vn2czwy87BWP7OZeSrwm/LyJb16X0kVQ6E0gspF+hkRF5XXO0fEWRGxsNxYcH1EfCointjHbrwZeAzVEZdPd9tYRGwF/AfV0a53DKsfw9bF5/Dysv5jZl7ZpMy36r7ec4L9vfgshz0eV5f1+kN473+IiM+V39H/m6Tc70u5YybY9+yGm3T+Vm4auiwi5kbE9v37DqRHW2nYHZDUWkT8G3ACj/xP3CbAu4DXRsTzM/P3fXjrl5b1rzLzxrr+rAQ83HikqpWIWAH4H6p/cz6QmX8eRj/q6q6cmQ+1UX4+sBFt3jgxQTvdfA61I38/b1YgM2+JiAXABnXl6/Xis+z5eLRp3bK+d6oV2h3vKdqqrK9q8b4zgE0nKhcR76a67rLRk8uyI9W1lHt03VNpijxSKI22TYHPA1cAL6S6rmwzqusDl1AdLTknIlbp5ZuWP/DblJeXR8RqEfGhiLie6g7XJRFxXUR8ppxOnMzbge2p/jAeN8R+HBcRi4AHyxHX/4uIT0TErKn2qUudfg4bsOzU8Z8mKV67ceWfGtro+rPsw3i0JSLWpbqhBeDSKVTp53hvWdbNjtpCFRxrf2d/VdsYEU+lunEG4ELgxVT/6Vi7tPsK4GTaCL5STwz7okYXF5dHL1R/EGoXy/8KWG2CMgfUlXnXFNo8uq787EnKPqmu7GepTtllk+UuYOcWbW1Idar0YWD7hn0tb7DoRT945I0HzZbFwGtafA/zS7n5XYxpN5/DVnVlDp/kfc4o5e7sw2fZs5+LDj/DL9e1/6ImZboe7ymOZa2t57Yod3gpswhYoW7728r224CVe/kZubh0s3ikUBp9czLzb40bs5qLbl55+aYev+fj674+FNgcOJvqKNEqVEco3011dOgJwJktpgg5geoo1xcy8/Ih9GMp8EOqz2jLUm5V4BlUd9E+CDwOOCUiXjhRJzJzdmZGdnHqmO4+h8fVff3AJGXvL+sZDdt78Vn28ueiLRHxGpb9nH8nM3/QpGjX4z0FW5d17T9tzdRO4f86M5fWba9dunVH9v60ttS5YadSFxeXRy8sO1K4GFixRbkjS7mlwJqTtHk0Uz9SuDmPPLJyHg1ToJRyr6orc2yL/bcCj59g/2RHyHrSj0m+12dTBakE/tDq8+5iPLv9HHaqK3PQJO/1jVLuwV5/loMYjybf0/bAfaW9m4C1u2ir6/EG3l+rP0m5q0q54xq271r3+cwF1ur1z5yLSyeLRwql0XZdZj7cYv/vyjqoLk7vlcUNr4/OzGwslJnfYtkUIXvV74uINYFjy8t3ZmYn10d13Y/JZOalwH+Vl5sB/9JmH1vqw+ew6iRla9eXNn52vfgs+z4ejSLiaVThczXgTuDF2cWk0z0a763Kuun1hBGxMlWIhoabTDLzIqrJxwGOAG6LiJ+XGQX2LE+LkQbOUCiNtsY/wq32T/Z4sHbcSXUUA6qjKle0KFt7UsqTy92WNR8E1gPOz8z/HWI/puI7dV9v07RUZ3rxOdSHoHUmKVvbf2fD9l58loMaDwAi4snA+SybuPslmXlNJ2016Ha8a6HwqhZltgBWblHuVVTzPf4JWBHYgWpGgbOB2yPi8zHJc56lXjMUSqNtsj+m9fsX9epNM/M+4Oby8t585PVQje6u+7r+j9jGZb17maftUUtd2TfWbd+rx/2Yitvrvl6zzbqT6cXnsIBl/wF4yhTf79r6jb34LAc4HrU7jS+guqnjfuDl2f61mM10PN7lKN4m5WWrO4+3Leu/s2xuxX/IzCWZ+anM3ITqiOUBwBepnkqzGtVNKheWO76lgTAUSqNts4hYscX+fy7r2rVWvVT7A7xmmV+vmbXqvr6nx30YVD/W66LuoNQCyA7NCpSbOmo3dkwUWHrxWfZ9PCLiCVRHCDejmnpp38y8uJ02JtHNeG/Jsr+dv21RbteyviYzH2zVYGZen5lfz8y3UIXg2unt7XCeQg2QoVAabY8Ddm+x/5VlfU1m3tPj9z6rrFehRRABdinrP+Qj75L+D6pTc62WmnPqtv24x/2Yir3rvm519KcTvfoczinrTSOi2SnPV9V9/Z0J9p9V1t18lr1oo6lyqvl7VHcLLwVen5nfnWr9KepmvLeq+3rCO8EjYibLrqVsdYr5UTLz71Q3hdX8c5OiUu8N+04XFxeXRy8MeZ7CUn5V4JZS/gImuEuT6nm8tTaP7uD7bHnXbS/6AcyapA+7Uv1xr92NukK730cPxnsqn0PturqkCk3RsP+JVHc3J/Dzfo1pP38ugMdSTeY8pTutm7TR1/EGTqzr3x4T7F+J6rrAWpn/mKDMZq3el+oIYa3+wYP+eXRZfpehd8DFxeXRS10oXAA8BPwSeAHVKblNgKPK9toftlUmaGNzqkdl1ZYv1v2h2bth38wm/aifWuSHVFOjPJHqSSv1ffgjE0y1MoXvc9Iw1G0/gDuoJnR+A9XF/2uV5V+Az9TVXQLs3uT955cy8/s03lP9HN5bV/YMqvny1qY6mvx/dd/HTv34LHvVBo+cYPrksm1FqqOQte0foLpmttUy0XQ4XY/3JGNwWV0fbwUOBJ5Kda3nflS/q1m3fAbYdYLf7xuAY8rYbUh1beMmVPMr3lTqLgaeNIh/c1xcMg2FLi4jubAsFF4EvJXqKRg5wbIAeFqTNi5qUmei5cAWfXkX1cXyzepeBzy1w+9zSmGom35QXTM22fd/F7B3i/eezwiEwlL2xBbfx4PAAf36LHvVBhOHwtkt2mq2zO7HeLf4noMqqCXw31SntxvbXgK8o2HbNU1+v1stfwP26sfPm4tLs8VrCqURl5lfoDpKeC7VXZMPUh2B+QzwjMz8fZ/f/9NU1459FbixvP+9wM+pnl6xVWb+oZ996LIfb6J6JNulVEdg7qM6WnQb8COqeeI2y8wz+/099EJmHgK8HPgu1ffwENX39RVgu6yedDNZG12P6aj8XEygn+O9KcueLvMZqiPuV1Cdjr6T6jrOZ2XmsVTh/W9U4fgzDe0cQXUk82Sqy0NuowrYi6iuQfwk8E+ZeVYHfZQ6Fpk57D5IahARJ1Ndl3VxZu463N5IAoiIfYHTqELgjGw9sbw07XikUJKkqdm6rH9nINQ4MhRKkjQ1W5V1q/kJpWnLUChJ0tQYCjXWDIWSJE2iPGVlw/LSUKixZCiUJGlyW9V9bSjUWPLuY0mSJHmkUJIkSdUzGtWFtddeO2fPnj3sbkiSJE3qiiuu+Etmzpxon6GwS7Nnz2bevHnD7oYkSdKkIuLGZvs8fSxJkiRDoSRJkgyFkiRJwlAoSZIkDIWSJEnCUChJkiQMhZIkScJQKEmSJAyFkiRJwlAoSZIkDIWSJEnCUChJkiQMhZIkScJQKEmSJAyFkiRJwlAoSZIkDIWSJEnCUChJkiQMhZIkScJQKEmSJAyFkiRJwlAoSZIkDIWSJEnCUChJkiRgpWF3QJJG2ew55/W0vflzX9bT9iSpVzxSKEmSJEOhJEmSDIWSJEnCUChJkiQMhZIkScJQKEmSJAyFkiRJwlAoSZIkDIWSJEnCUChJkiQMhZIkScJQKEmSJAyFkiRJwlAoSZIkDIWSJEnCUChJkiQMhZIkScJQKEmSJAyFkiRJwlAoSZIkDIWSJEnCUChJkiRgpWF3QJJ6Zfac84bdBUmatjxSKEmSJEOhJEmSDIWSJEliBENhRKwaEe+NiMsj4p6I+FtE3BARp0XETk3q7B8Rl0TEvRGxOCLmRcRhEdHy++u0niRJ0rgZqRtNImJj4IfApsDtwMXAg8Bs4BXAr4GfNdQ5HjgUeAC4EFgC7AYcB+wWEftl5sMTvFdH9SRJksbRyITCiHgccD6wCfAR4COZuaRu/1rAWg119qEKdguBnTPzurJ9XeDHwN7A4cCxvagnSZI0rkbpNOn7qQLh1zLzqPpACJCZd2bmHxrqHFnWR9SCXSl7G3BIeTlngtPBndaTJEkaSyMReiJiZeAt5eXcKdaZBWwLPASc1rg/My8GFgDrATt2W0+SJGmcjUQopAppawE3Z+bvIuLZEfGxiPjviPhQRDxrgjrblPXVmXl/k3YvbyjbTT1JkqSxNSrXFD6jrK+LiJOBNzbsPyoizgDeUBfkNi7rG1u0e1ND2W7qSZIkja1ROVL4xLLeGTgA+BTVHchPoLrreAGwD3B8XZ0ZZX1fi3YXl/XqPagnSZI0tkYlFNb6sRLwpcx8T2b+MTPvyczvAHsBCbwxIp5SykZZZ5vv1Wm9ZQ1EHFzmNJx3xx13dNqMJEnSyBiVULio7uv/adyZmfOAK6j6u2tDnRmN5evU9tW332m9+v6clJnbZeZ2M2fObNGMJEnS9DAqoXB+3dc3NClT275eQ52NWrS74QTtd1pPkiRpbI1KKLyy7uu1mpRZu6xr1/tdVdZbRMSqTeps31C2m3qSJEljayRCYWYuAH5RXu7WuD8ingA8s7ycV+rcTBUmVwb2m6DOLsAsqqeWXFb3Xh3VkyRJGmcjEQqLj5b1URGxdW1jRKwCnAg8nuq6wvqgdkxZfzwiNq2rsw5wQnk5NzOXNrxXp/UkSZLG0qjMU0hmnhMRnwLeDfwiIn4B3An8C7A+1bQ0r83MrKtzekScSPVout9ExAXAEqqjjWsAZwHHTfBeHdWTJEkaVyMTCgEy8z0RcSnwNqqniaxGNZH0Z6iO3D1q/pfMPDQifgocBuwCrAhcC3wZOLHZ0b5O60mSJI2jkQqFAJl5JnBmm3VOBU7t4L06qidJkjRuRumaQkmSJA2JoVCSJEmGQkmSJBkKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSYxQKIyIkyMiWyzXtqi7f0RcEhH3RsTiiJgXEYdFRMvvr9N6kiRJ42alYXdgAj8Drp9g+60TFY6I44FDgQeAC4ElwG7AccBuEbFfZj7cq3qSJEnjaBRD4Rcz8+SpFIyIfaiC3UJg58y8rmxfF/gxsDdwOHBsL+pJkiSNq+l+mvTIsj6iFuwAMvM24JDycs4Ep4M7rSdJkjSWpm3oiYhZwLbAQ8Bpjfsz82JgAbAesGO39SRJksbZKJ4+fl5EbAnMAG4Dfgqcn5lLG8ptU9ZXZ+b9Tdq6HNiglL20y3qSJEljaxRD4QETbLsmIl6Tmb+p27ZxWd/Yoq2bGsp2U0+SujZ7znk9bW/+3Jf1tD1Jy69ROn38K+DtwBZURwnXB/YAfg1sDlwQERvUlZ9R1ve1aHNxWa/eg3qSJElja2SOFGbm5xo23QecFxHnAxdTXd93JNVdwQBRq9rmW3Vab1kDEQcDBwM8+clP7rQZabnX66NmkqTOjdKRwgll5kPAMeXlS+t2LSrrGTRX27eoblun9er7dFJmbpeZ282cObNFM5IkSdPDyIfCovY0k/rTx/PLeqMW9TZsKNtNPUmSpLE1XULhWmW9uG7bVWW9RUSs2qTe9g1lu6knSZI0tqZLKHxVWV9e25CZNwNXAisD+zVWiIhdgFlUTy25rNt6kiRJ42wkQmFEbB0Re0TEig3bV4qId1LdlQzw2YaqtWsNPx4Rm9bVWwc4obycO8Ech53WkyRJGkujcvfxbOBM4K6I+ANwC9V0MM+gmppmKdUj6X5QXykzT4+IE6keTfebiLgAWALsBqwBnAUc1/hmndaTJEkaV6MSCn8NHAv8C9UNINtQTRlzC/AV4PjMvGKiipl5aET8FDgM2AVYkerGlC8DJzY72tdpPUmSpHE0EqEwM28A/r2L+qcCpw6qniRJ0rgZiWsKJUmSNFyGQkmSJBkKJUmSZCiUJEkShkJJkiRhKJQkSRKGQkmSJGEolCRJEoZCSZIkYSiUJEkShkJJkiRhKJQkSRKGQkmSJGEolCRJEoZCSZIkYSiUJEkShkJJkiRhKJQkSRKGQkmSJAEr9aKRiHgBsBVwI3BmZj7ci3YlSZI0GFM+UhgRb4mIayLiOQ3b/wf4AfAJ4JvABRHxmN52U5IkSf3UzunjVwLrAb+obYiIZwEHAYuBbwA3ADsD+/ewj5IkSeqzdkLh5sBvM3NJ3bbXAAm8NjMPAHYA/ga8qXddlCRJUr+1EwrXBhY0bNsZuDszvwuQmXcClwCb9KZ7kiRJGoR2QuEKwGNrLyJiNeDpwM8ayt1JFSAlSZI0TbQTCm8Btq57vTuwIo8OhWsCd3fVK0mSJA1UO6HwB8BGEXF8ROwJfJzqesJzG8ptDdzUm+5JkiRpENoJhR8FbgcOAc4EngqcmpnX1ApExDbABsClveykJEmS+mvKk1dn5q0l9L0FWBf4JfD1hmJPB84GzuhZDyVJktR3bT3RJDMXAh9psf/rPDooSpIkacT57GNJkiQ1D4URcVS5oWSifVtGxKwm+94WEd/uVQclSZLUf62OFB4N7NVk31XAh5rseybwis67JEmSpEHr9PRxlEWSJEljwGsKJUmSZCiUJEmSoVCSJEkYCiVJkoShUJIkSUz+RJOtI+KoNvdt3V2XJEmSNGiThcKtyjKRrZvsCyC76JMkSZIGrFUo/OrAeiFJkqShahoKM/NNg+yIJEmShscbTSRJkmQolCRJUovTxxHx5G4azsybuqkvSZKkwWl1o8kNXbSbk7QtSZKkEdIquN1P+1PLPHaSNiVJkjSCWt19PGOqjUTETOD9wL+VTfd12S9JkiQNUFc3mkTE4yLig8D1wOFUE1efAGzag75JkiRpQDo61RsRjwEOAd4HzCyb/x/wgcz8U4/6JkmSpAFpOxRGxBuADwEbUR0Z/D5wZGb+usd9kyRJ0oBMORRGxB7AR4GnU4XBnwNzMvMnfeqbJEmSBmTSUBgRzwbmAjtRhcFrgPdn5ln97ZokSZIGpdXk1VsAxwAvowqDNwNHA1/NzKUD6Z0kSZIGotWRwl9ThcG/Af8FHAc8CKwZEZM2nJl39aKDkiRJ6r9WoXAFqsmrVwPmlGWqfKKJJEnSNDJZcJv8kGBv60mSJGkIWj3RpKuJrSVJkjR9GPwkSZJkKJQkSVJ7k1fPAHYFtmXZo+3uAK4ALsrMxT3vnSRJkgZiKpNXPwY4CngbsHqTYosj4jjgQ5n5UA/7J0mSpAFoGQojYg3gfGA7qjuK7wWuAm4rr9cBtgEeTzVlze4RsXtm3tvPTkuSJKm3Jrum8FvA9sB8YD9g7cx8fma+NjNfk5nPB9YGXg3cRBUev9WLjkXExyIiy/LuFuX2j4hLIuLeiFgcEfMi4rCIaPm9dVpPkiRpHDUNQBGxB/BCqiODz8zMMzLz4cZymflwZp4GbA38CnhBqduxiNgeeC/VJNityh0PfIMqjF5CdVTzqVRPXzk9IlbsZT1JkqRx1eqo2OuBpcAbpnI6uJR5Q13djkTEY4GTqU5Rn92i3D7AocBCYMvM3CMz9wY2A34H7A0c3qt6kiRJ46xVKHwWcGVmXjPVxjLzaqq7kZ/VRZ8+DGwOvJXqGsZmjizrIzLzuro+3AYcUl7OmeB0cKf1JEmSxlar4LMOcH0HbV5f6rYtInYA3gWcmpnntCg3i2pqnIeA0xr3Z+bFwAJgPWDHbutJkiSNu1ah8AFg1Q7aXLXUbUtErAJ8FbgLeMckxbcp66sz8/4mZS5vKNtNPUmSpLHWakqaG4Ed2mksIqLUuamDvnwUeBrwmsz8yyRlNy7rG1uUqfVh47ptndaTJEkaa62OFF4ArBsRB7XR3kFUp15/2E4nIuLZwL8DZ2XmN6dQZUZZ39eiTO0JK/UTbndaT5Ikaay1CoXHAUuAz0fEKyZrKCL2Aj5Pdb3e8VPtQESsCnwF+CvVXcFTqlbWLaes6WG9RzYScXCZ13DeHXfc0U1TkiRJI6FpKMzM+cARwCrAtyPi7Ih4ZUTMiojHlGVWROwTEecAZwCPBY4sdafqY1RzBL4zM2+dYp1FZT2jRZnavkV12zqt9wiZeVJmbpeZ282cObNZMUmSpGmj5WPuMvPYiFgJOAZ4OdBsUuoAHqYKhJ9tsw97U82H+MaIeGPDvn8q60PKhNjXZ+a/Uj1hBWCjFu1uWNbz67Z1Wk+SJGmstQyFAJn56Yj4HtVRw5cBT2wocjdwLvDJzPxth/1YAdilxf6nlGXN8vqqst4iIlZtcifx9g1lu6knSZI01qY0QXNmXpOZb8zMtYFNqObw2xHYNDPXKvt+CxAR60bEk6fagcycnZkx0UI1RQ3Ae8q2rUudm4ErgZWpnsn8CBGxCzCL6qkll9W9V0f1JEmSxl3bT+3IzBsy85dl+dMERc4CJtrea8eU9ccjYtPaxohYBzihvJybmUt7VE+SJGlsTXr6uEMxeZHuZObpEXEi1aPpfhMRF1DdLb0bsAZVOD2uV/UkSZLGWb9C4UBk5qER8VPgMKprElcErgW+DJzY7Ghfp/UkSZLG1UiHwsw8EDhwkjKnAqd20HZH9SRJksZR29cUSpIkafwYCiVJkmQolCRJUotrCiNi5w7bXKPDepIkSRqSVjeaXARkB21Gh/UkSZI0JK1C4U0Y7iRJkpYLTUNhZs4eYD8kSZI0RN5oIkmSJEOhJEmSJgmFEfHNiLgiIp4zWUMR8ZxS9pTedU+SJEmD0DQURsRuwH7AdZn508kaKmX+ALw2Ip7buy5KkiSp31odKXwt1d3HR7fR3geppqR5XRd9kiRJ0oC1CoU7An/IzGun2lhm/gH4HbBTtx2TJEnS4LQKhU+mCnjt+j2wUWfdkSRJ0jC0CoWPBe7voM37gZU7644kSZKGoVUovBNYv4M21wfu7qw7kiRJGoZWofBq4F8i4nFTbSwiZgA7lLqSJEmaJlqFwu8BqwJHttHekVSnnb/bTackSZI0WK1C4UnAXcCciHj7ZA2VMnOoTh3/T2+6J0mSpEFYqdmOzFwcEQcA3wE+GxFvBL4OXA7cXoqtA2wPHABsVbYdmJmL+tdlSZIk9VrTUAiQmd+NiFcCXwO2AbZuUjSAv1IFwnN72kNJkiT1XctQCJCZ34mIpwBvB/YEtmTZaeelwP9RHU08LjP/0q+OSpIebfac83re5vy5L+t5m5JG36ShECAz76J63N3REbEisFbZdWdmPtynvkmSJGlAphQK65UQePukBSVJkjRttLr7WJIkScsJQ6EkSZIMhZIkSTIUSpIkCUOhJEmSaBEKI2KNiFhlkJ2RJEnScLQ6Ung3cHztRUQcFRF79r9LkiRJGrRWoTDKUnM0sFc/OyNJkqThaBUK/wY8cVAdkSRJ0vC0eqLJtcDuEfFm4Pqybb2I2HkqDWfmT7rtnCRJkgajVSj8AnAS8D91215UlsnkJG1LkiRphDQNbpn5xYhYCOwLbAg8j+qZx9cOqG+SJEkakJZH8zLzXOBcgIhYCnwvM988iI5JkiRpcNqZvPqrwE/71RFJkiQNz5Sv+8vMN/WzI5IkSRqejm4GiYhnAbsCG5RNC4CLMvOyHvVLkiRJA9RWKIyI2cA3gB1rm8o6y/7LgNdn5vwe9U+SJEkDMOVQGBFPAH4MbATcB5wD/JEqGG4MvBx4NvCjiNg2M+/ufXclSZLUD+0cKXwvVSA8A3hrZt5ZvzMinkg1t+G+wHuA9/Wqk5IkSeqvdu4+fgVwK9Xp4Tsbd2bmXcAbSpm9etI7SZIkDUQ7oXA2cElmPtisQNl3SSkrSZKkaaKdULgEWG0K5VYtZSVJkjRNtBMKfwc8LyLWa1ag7Ht+KStJkqRpop1QeArwOOCCiHh+486IeB7wQ6qjiV/vTfckSZI0CO3cffwFYB9gF+D8iPgzcAPVHIUbU01kHVTT1nyhx/2UJElSH035SGFm/h14MfApqnkKNwCeAzwXmFW2fQp4aWY+3PuuSpIkqV/aeqJJubv4vRFxFLAty44O3gJckZkP9L6LkiRJ6reOnn1cwt/PetwXSZIkDUk7N5pIkiRpTBkKJUmSZCiUJEmSoVCSJEkYCiVJkoShUJIkSbQRCiNiz4h4ST87I0mSpOFo50jhmcC/96kfkiRJGqJ2Jq++C/hLvzoiafTNnnPesLsgSeqTdo4U/hJ4er86IkmSpOFpJxR+HNgiIg7qV2ckSZI0HO0++/gLwEkRsS/VNYY3AvdPVDAzf9JOwxHxNuC5wDOAdYA1gHuAXwMnA9/IzGxSd3/gEGBLYEXgWuArwImZubTFe3ZUT5Ikady0EwovAhII4EXAC1uUzTbbBjiCKgz+FrgUuA/YCHg+sBuwb0S8sjGsRcTxwKHAA8CFwJJS/jhgt4jYLzMfbnyzTutJkiSNo3aC20+owl6/vAa4KjPvq98YEVtQhbZXAG+kOpJX27cPVbBbCOycmdeV7esCPwb2Bg4Hjm1os6N6kiRJ42rKoTAzd+1jP8jMnzbZfnU5qvdhYHfqQiFwZFkfUQt2pc5tEXEI1dHNORHx+YYjjJ3WkyRJGkvT5Ykmfy/rB2obImIWsC3wEHBaY4XMvBhYAKwH7NhtPUmSpHHWcSiMiJUj4kkR8cRedmiC99kYeGt5eU7drm3K+urMnPBmF+DyhrLd1JMkSRpbbYfCiDggIi6nuhHkFuBTdfv2jYhTS5DrSES8KSJOjohvRMTFwB+AWcAxmXlmXdHae9zYormbGsp2U0+SJGlstXWHcEScDLyB6g7kxcCMhiI3U24YAT7ZYZ92orqhpObvwAeAzzSUq733fTS3uKxX70E9SZKksTXlI4UR8UbgAKp5A7cDHt9YJjN/AfwZeEmnHcrMf83MAFYDtgA+BxwN/Dwi1q/vUq1Km2/Rab1lDUQcHBHzImLeHXfc0WkzkiRJI6Od08dvARYBL8/MK5tNJA38EZjdbccy8/7MvCYz30N1t/BWVHMI1iwq68ajlfVq+xbVbeu0Xn3fTsrM7TJzu5kzZ7ZoRpIkaXpoJxQ+A/h5Zi6YpNyfqe7c7aXaNDQvj4jHlK/nl/VGLept2FC2m3qSJEljq51Q+BiWXWvXylpUTwfppXuori1cCajd7XxVWW8REas2qbd9Q9lu6kmSJI2tdkLhTcDTWxWIiBWprgP8YzedmsDOVIHwHuAvAJl5M3AlsDKw3wR92YXqruWFwGW17Z3WkyRJGmfthMIfAJtGxOtblPk34EnAee10IiKeGxGvi4jHTrBvJ+BL5eWXGp5HfExZfzwiNq2rsw5wQnk5d4KnknRaT5IkaSy1MyXNJ6mmivlyRGwOnF62rxIR/0x11O19wJ3A59vsxyZU1w0eFxFXUh2lW71s37yUOY9qapp/yMzTI+JE4BDgNxFxAdWp692ANYCzeOTNKV3VkyRJGlftPPv4lojYGzgDOKIsCby6LAH8Fdg3M29vsx8XAx8Bngs8FXh2aW9heb9TMvOsJv06NCJ+ChwG7AKsCFwLfBk4sdnRvk7rSZIkjaO2Jq/OzB+Xo4T/QTUX4VOowtTNwPeAT2bmLe12IjNvAI5qt15d/VOBUwdVT5Ikady0FQoBMnMhy44USpIkaQy0/exjSZIkjZ+2jxQCRMQGVNPEzKK6rvDPwE86OXUsSZKk4WsrFEbETKo7i/fh0UcZMyK+DRzewY0mkiRJGqIph8KIeCJwCbAZsBS4lGWPgZsN7AjsC2wVEc/KzLt62lNJkiT1TTtHCo+mmi7mQuCtmfmIp5ZExMbAF4AXAB8E3tGjPkqSJKnP2rnRZC/gDmCvxkAI/5hW5pVUj6Hbuye9kyRJ0kC0EwrXAS7OzPuaFSj7LgZmdtsxSZIkDU47oXABsPIUyq1MdTeyJEmSpol2QuFpwPMjYr1mBcq+51M9mk6SJEnTRDuh8MPA1cCPI+IljTsj4sVUN6FcTXWjiSRJkqaJpncfR8SPJtj8MPA04NyIuIdHTkmzZvn6MuBcYLce9VGSJEl91mpKml1b7AvgCWVp9Gyqp5xIkiRpmmgVCp83sF5IkiRpqJqGwsy8eJAdkSRJ0vC0c6OJJEmSxpShUJIkSW09+5iIeAJwKNX1husDqzQpmpm5SZd9kyRJ0oBMORRGxKZUj7Bbj+ru41a8+1iSJGkaaedI4aeBJwGXAJ8FrgMW96NTkiRJGqx2QuGuVJNV756ZD/WlN5IkSRqKdm40SeCXBkJJkqTx004o/BXV9YSSJEkaM+2Ewk8Bz4mIZ/erM5IkSRqOKV9TmJnnRsR/AOdFxHHAD4BbgKVNyt/Umy5KkiSp39qapxC4CrgNeF9ZmskO2pYkSdKQtDNP4a7A94GVy6Y7cUoaSZKksdDO0byPUAXCTwBzM/OevvRIkjRUs+ec19P25s99WU/bk9Qf7YTCrYErMnNOn/oiSZKkIWnn7uP7qZ5iIkmSpDHTTii8BNiiXx2RJEnS8LQTCj8AbBIR7+hXZyRJkjQc7VxTuB3wFeAzEbEvk89T+LXuuydJkqRBaCcUnkw1/2AAOwGTPdnEUChJkjRNtBMKv0YVCiVJkjRm2nnM3YF97IckSZKGqJ0bTSRJkjSmDIWSJElq69nHB7TTsHcfS5IkTR+d3H08mSjlDIWSJEnTRC/uPl4B2Ah4JvA44Czg3q57JkmSpIHp2d3HEbEOVXDclMnnMJQkSdII6dmNJpl5O7A/sAFwdK/alSRJUv/19O7jzLwLuBzYp5ftSpIkqb/6MSXNQ8CT+tCuJEmS+qSnoTAi1qN6LvIdvWxXkiRJ/dXOPIU7t9g9A/gn4DBgTeB/u+uWJEmSBqmdKWkuYvJ5CgO4Cnh/px2SJEnS4LUTCn9C81D4ELAAuBD4VmYu6bZjkiRJGpx25inctY/9kCRJ0hD14+5jSZIkTTOGQkmSJDU/fTzJ3caTysyfdFNfkiRJg9PqmsKLmPxu42ZykrYlSZI0QloFt2toPxRuDKzWeXckSZI0DE1DYWY+faqNRMQWwMeAzcumW7rslyRJkgaoqxtNImLDiPgK8CtgD+Bu4L3AU7vvmiRJkgalo+v+ImIt4D+BtwKrAH8DjgU+npl/7V33JEmSNAhthcKIWA14V1lWBx4GvgB8ODMX9r57kiRJGoQphcKIWInqqOB/AuuUzd8C3p+Zf+xT3yRJkjQgk4bCiHgd8CGqO4sD+CFwZGZe1ee+SZIkaUBaTV79EuAY4BlUYfCXwJzMvGgwXZMkSdKgtDpSeB7VPIV/A/4LOAMgIp45lYYz88queydJkqSBmMo1hasBc8oyVT7RRJIkaRppFdxuovPH3LUlIh4D7Ay8FNgJ2AhYC7gDuAw4rtVp64jYHzgE2BJYEbgW+ApwYmYu7XU9SZKkcdPqiSazB9iPXYDzy9cLgSuA+6iekLIPsE9EfCQzj2qsGBHHA4cCDwAXAkuA3YDjgN0iYr/MfLhX9SRJksZRV0806aGlVNcs7pyZT8rMPTLz1Zn5DOA1VPMhfiAinldfKSL2oQp2C4EtS729gc2A3wF7A4c3vlmn9SRJksbVSITCzPxRZu6bmZdMsO+bwMnl5esbdh9Z1kdk5nV1dW6jOi0MMCciGr/PTutJkiSNpekSempzIs6qbYiIWcC2wEPAaY0VMvNiYAGwHrBjt/UkSZLG2XQJhZuV9a1127Yp66sz8/4m9S5vKNtNPUmSpLE18qEwItYDDiwvz6jbtXFZ39ii+k0NZbupJ0mSNLZGOhSWZy6fAjweuDAzz6nbPaOs72vRxOKyXr0H9SRJksbWSIdC4AtU08TczKNvMomybncuxU7rLWsg4uCImBcR8+64445Om5EkSRoZIxsKI+JY4CCqaWN2y8yFDUUWlfUMmqvtW1S3rdN6/5CZJ2Xmdpm53cyZM1s0I0mSND2MZCiMiE8Db6d6oslu9dPG1Jlf1hu1aGrDhrLd1JMkSRpbIxcKI+ITwDuBO4HdM/OaJkVr09RsERGrNimzfUPZbupJkiSNrZEKhRExF3gPcDdVIPx1s7KZeTNwJbAysN8Ebe1CNa/hQqrnJ3dVT5IkaZyNTCiMiI8ARwD3UAXCqRylO6asPx4Rm9a1tQ5wQnk5NzOX9qieJEnSWFpp2B0AiIg9gfeXl9cDb4uIiYpem5lzay8y8/SIOJHq0XS/iYgLgCVUdyyvAZwFHNfYSKf1JEmSxtVIhELgiXVfb1eWiVwMzK3fkJmHRsRPgcOAXYAVgWuBLwMnNjva12k9SZKkcTQSoTAzTwZO7qL+qcCpg6onSZI0bkbmmkJJkiQNj6FQkiRJhkJJkiQZCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJGAolSZKEoVCSJEkYCiVJkoShUJIkScBKw+6AJGm8zZ5zXk/bmz/3ZT1tT1LFI4WSJEnySKE0znp9hEaSNL48UihJkiRDoSRJkgyFkiRJwlAoSZIkDIWSJEnCUChJkiQMhZIkScJQKEmSJAyFkiRJwlAoSZIkDIWSJEnCUChJkiQMhZIkSWKEQmFEPC0i3hERp0TEtRGxNCIyIvadQt39I+KSiLg3IhZHxLyIOCwiWn5/ndaTJEkaNysNuwN1DgHe0W6liDgeOBR4ALgQWALsBhwH7BYR+2Xmw72qJ0mSNI5GKRT+FvgkMA+4AvgSsEurChGxD1WwWwjsnJnXle3rAj8G9gYOB47tRT1J0vDNnnNez9ucP/dlPW9Tmm5G5jRpZn4xM9+bmd/KzD9OsdqRZX1ELdiVtm6jOvIIMGeC08Gd1pMkSRpL0zb0RMQsYFvgIeC0xv2ZeTGwAFgP2LHbepIkSeNs2oZCYJuyvjoz729S5vKGst3UkyRJGlvTORRuXNY3tihzU0PZbupJkiSNrekcCmeU9X0tyiwu69V7UE+SJGlsTedQGGWdA6q3rIGIg8uchvPuuOOOTpuRJEkaGdM5FC4q6xktytT2Larb1mm9f8jMkzJzu8zcbubMmZN2VJIkadRN51A4v6w3alFmw4ay3dSTJEkaW9M5FF5V1ltExKpNymzfULabepIkSWNr2obCzLwZuBJYGdivcX9E7ALMonpqyWXd1pMkSRpn0zYUFseU9ccjYtPaxohYBzihvJybmUt7VE+SJGksjcyzjyPimSwLZACbl/XHIuLdtY2ZuWPd16dHxIlUj6b7TURcACwBdgPWAM4Cjmt8r07rSZIkjauRCYVUYWyHCbZv1qpSZh4aET8FDgN2AVYErgW+DJzY7Ghfp/UkSZLG0ciEwsy8iGVzCLZb91Tg1EHVkyRJGjfT/ZpCSZIk9YChUJIkSYZCSZIkjdA1hdLybvac84bdBUnScswjhZIkSTIUSpIkyVAoSZIkDIWSJEnCUChJkiQMhZIkScJQKEmSJAyFkiRJwlAoSZIkDIWSJEnCUChJkiQMhZIkScJQKEmSJAyFkiRJwlAoSZIkDIWSJEnCUChJkiQMhZIkScJQKEmSJAyFkiRJwlAoSZIkYKVhd0CSpGGbPee8nrY3f+7LetqeNAgeKZQkSZKhUJIkSZ4+ljrW69NNkiQNk0cKJUmSZCiUJEmSoVCSJEkYCiVJkoShUJIkSRgKJUmShKFQkiRJOE/htOEjmLrnvIKSJDXnkUJJkiQZCiVJkmQolCRJEoZCSZIk4Y0mkiT1nDcHajrySKEkSZIMhZIkSTIUSpIkCUOhJEmSMBRKkiQJ7z7WiPKRdJIkDZZHCiVJkmQolCRJkqFQkiRJGAolSZKEoVCSJEkYCiVJkoRT0kiSNPJ6PU3X/Lkv62l7Gg8eKZQkSZKhUJIkSZ4+Xm55KkKSJNXzSKEkSZIMhZIkSfL0sXqk16ejJUnSYBkKJUlazvTjP/JeWz79efpYkiRJhkJJkiQZComI/SPikoi4NyIWR8S8iDgsIpb7z0aSJC0/luvgExHHA98AtgMuAc4HngocB5weESsOsXuSJEkDs9zeaBIR+wCHAguBnTPzurJ9XeDHwN7A4cCxQ+ukJEnThA9FmP6W21AIHFnWR9QCIUBm3hYRhwAXAXMi4vOZuXQYHZQkaXllyBy85fL0cUTMArYFHgJOa9yfmRcDC4D1gB0H2ztJkqTBW16PFG5T1ldn5v1NylwObFDKXjqQXkmSpL5wbsbJLZdHCoGNy/rGFmVuaigrSZI0tpbXI4Uzyvq+FmUWl/Xqfe6LJEmahsbtusflNRRGWWdHlSMOBg4uLxdHxO970qvW1gb+MoD3UX84ftOb4ze9OX7T23IzfvHxgbzNRs12LK+hcFFZz2hRprZvUeOOzDwJOKnXnWolIuZl5naDfE/1juM3vTl+05vjN705foOzvF5TOL+sm6ZlYMOGspIkSWNreQ2FV5X1FhGxapMy2zeUlSRJGlvLZSjMzJuBK4GVgf0a90fELsAsqqedXDbY3jU10NPV6jnHb3pz/KY3x296c/wGJDI7utdi2ouIfakmrl4IPDczry/b16F6zN3mwL9npo+5kyRJY2+5DYUAEXECcAjwAHABsATYDVgDOAvYNzMfHloHJUmSBmS5PH1ck5mHAq+jOpW8C/Ai4HrgcGCfYQfCiNg/Ii6JiHsjYnFEzIuIwyJiuR63QYmIkyMiWyzXtqjb0dg55u2JiKdFxDsi4pSIuDYilpax2XcKdQc6Ro7txDoZw25+N0t9x7AHIuIxEbFbRHw6In4eEbdGxEMRsSAiTo+IXSep7+/gqMlMlxFcgOOp5lG8HzgXOBP4a9n2bWDFYfdx3Bfg5PJ5/7R83bgc08uxc8w7GqPPlc+ncdl3knoDHSPHtrdj2OnvpmPY87F7Qd143Vo+l28Cv6nb/uFRGAfHb4pjOuwOuEwwKLBP3S/ZZnXb1wWuKfveMex+jvtS94fnwH6PnWPe8Rj9K/AJ4FXAJsBFUwgUAx0jx7YvY9j276Zj2Jexez5wOtV1+Y37Xg38vXw2zxvmODh+bYzpsDvgMsGgwLzyQ3rABPt2qfvhXmHYfR3npZM/PJ2OnWPeszGbSqAY6Bg5tn0Zw7Z/Nx3DoYzlF8tn86VhjoPjN/XF8+gjJiJmAdsCD1HdHf0ImXkxsABYD9hxsL1TK52OnWM+OIMeI8d2dDiGQ3FVWc+qbfB3cLQZCkfPNmV9dWbe36TM5Q1l1V/Pi4jPRMRJEfGRiHhRkwuTOx07x3xwBj1Gjm1/TfV3ExzDYdisrG+t2+bv4AhbXp99PMo2LusbW5S5qaGs+uuACbZdExGvyczf1G3rdOwc88EZ9Bg5tv011d9NcAwHKiLWAw4sL8+o2+Xv4AjzSOHomVHW97Uos7isV+9zX5Z3vwLeDmxBNS7rA3sAv6aa3PyCiNigrnynY+eYD86gx8ix7Y9f0d7vJjiGAxMRKwGnAI8HLszMc+p2+zs4wjxSOHqirHOovRCZ+bmGTfcB50XE+cDFVNefHEk1ryV0PnaO+eAMeowc2z7o4HcTHMNB+gLVgyBuBl7fsM/fwRHmkcLRs6isZ7QoU9u3qEUZ9UlmPgQcU16+tG5Xp2PnmA/OoMfIsR2gFr+b4BgOREQcCxxE9QjZ3TJzYUMRfwdHmKFw9Mwv641alNmwoawGr/bEhPpTVPPLut2x67Se2je/rAc1Rp3WU+cm+t0Ex7DvIuLTVKf176AKhNdNUGx+Wfs7OIIMhaOndgv/FhGxapMy2zeU1eCtVdaL67Z1OnaO+eAMeowc28Gb6HcTHMO+iohPAO8E7gR2z8xrmhT1d3CEGQpHTGbeTPUs5pWB/Rr3R8QuVHM+LQQuG2zvVOdVZV2byqDjsXPMB2fQY+TYDsWjfjfBMeyniJgLvAe4myoQ/rpZWX8HR9ywZ892efQC7MuyGdY3rdu+DnA1PpJnEGOwNdXdjCs2bF+J6n/DD5dxeFEvxs4x79m4XcTkT8MY6Bg5tr0dw05/Nx3Dvo3XR8r3fzew7RTr+Ds4okuUD0YjJiJOAA4BHgAuAJZQ3c21BnAW1T+YDw+tg2MuIvaiemD6XcAfgFuopit4BtX0F0uBIzPzExPU7WjsHPP2RcQzgRPqNm1ONU7XUY0dAJm5Y0O9gY6RY9tcu2PYze9mqe8Y9khE7AmcXV7OowpYE7k2M+c21PV3cBQNO5W6NF+A/YGfAX+lmnLhCuAwfD7jID77jYHPAZdSPQLpAeB+qj9UX2aS/xF3OnaOedvjtCvV//JbLqMwRo5tb8aw299Nx7CnY3fgVMYOuGgUxsHxm3zxSKEkSZK80USSJEmGQkmSJGEolCRJEoZCSZIkYSiUJEkShkJJkiRhKJQkSRKGQkk9FBHZwXJyn/oyv7Q/u406J5c6B/ajT8MWEQf2+TM/MSIejojN+9H+JO/9yvK9HT7o95bGxUrD7oCksfLVCbatB7yI6gkCp0+w/6d97dFyJCLmAxsBG2fm/AG/91bAW4BTMvOaQb43QGZ+OyLmAR+KiFMz865JK0l6BEOhpJ7JzAMbt0XErlSh8C8T7e+j3YDHUD0KTf33SaqzTx8eYh8+DHwHeB/w7iH2Q5qWPH0saSxl5h8z89rMXDLsvoy7iNgC2J3qGbd/HGJXvgssBP41Ih43xH5I05KhUNLQ1F/DFxHPiIjTImJhuS7t30uZ1SPi4Ig4KyKuj4i/RcTiiLgqIv4zIlZt0nbb1xROob87RMT/i4hbIuKhiLgjIr4TEc9pUj4jIsvXr46Iy0rfF0XEhc3qlfJbR8TZEXFXRNwXEVdExJsb2y2vDyyvNyqbbmi4bvNRn0H5XD8ZETdExIMRsaBcE/jEDj6aQ8t6ossHHjEWEbF7+d7vLWP584jYs0m99SPiuDLuD5TyN0XE9yPi4Mbymfkw8A3g8cD+HXwf0nLNUChpFOwEXA48E7gI+D7wt7JvK+C/gWcBf6Y6PXgZsAnw/wEXRcQq/e5gRLyrvO+rqI5GnQ1cD7wMuDgi3tKi7oeBU4GHgPOAW4DnAxdGxLMmKP/88l57ArdRfc9/BU6KiE9O8BbXUwWy+8rrM8rr2rK4ofzjgZ8BbwZ+BfwQWA14K3B+RDym+ScxoVeU9QWTlDsI+AEwg+qo3rXADsBZEbFvfcGIeBJwBXAY1aVO3wfOAW4CdgTe2eQ9an14RZP9kprJTBcXF5e+LcCuQALzJ9h3ctmXVAFvhQnKzKIKUCs0bF8T+F6pe8QE9eaXfbPb6GutPwc2bH9x2b4A2KFh307AvVSB76kN+2rf253AtnXbVwBOKvvOb6izGlX4TeBDQNTtezawqNZuu98zcGBdn84DZtTtW58qcCXwujY+s81KnZtalKn160HgxQ373l/2Xdew/aiy/Qv1n0HZ91hg5ybvtSawlCpErzTsn38Xl+m0eKRQ0ii4FvhgZi5t3JGZt2Tmjxr3ZeY9wNvLy30b6/XYh8r6XzPzFw39+BnwEaqbWv6tSf0PZuYVdXWWUoUhgOc2HJnbF3gS8AfgQ5mZdfUuBU7o5hspFgMHZeY/jiBm5p+B48rL3dpoa+uy/t0Uyn4+M7/fsO0TVKF604h4ct32dcv6+/WfQenrg5n5k4neoPxc3AqsTnU0WdIUefexpFFwdlbXg00oIoLqiNzOVEcOVwWiLABP7VfHImJtYHuqI08/bFLs4rJ+1Kng4tzGDZl5e0TcDTwBWIvqlDTALmX9zYlCMtVp6PdOoeutXJGZCyfYfm1Zr99GW+uU9Z1TKDvR5/BQRPwJ2IZlRysBfkl1reLHq+Hn/My8r7F+E3eVttYFfj/FOtJyz1AoaRTc2GxHRKwLfJvq1Gkza/S8R8tsTBU+1wD+XgJKMzObbL+pyfa/UoXC+msiNyjrZp9J08+qDa36Q0N/JvP4hrq9et+vAy+kumHkTODhiPgt8BPg/5Wjps3U2ltzCn2SVBgKJY2C+1vs+yJVIPwZcDTwa+CezFwSEStTXafWTyuW9b3AWZOU/ctEG5sc8ZtMNtneSVv9aKPmnrKeSjCf8vuWz+x1EXEMsAfVkeKdgLcBb4uIL2fmQU2q1/py91TfT5KhUNIIK3PNvRR4GNijXC9Wb9MBdOPmsl6Sg5l8+89lvVGT/bMH0Id23F7Wa/Wj8cz8LfBbgIhYgern4VTgzRHxzcyc6JR+rS+3T7BPUhPeaCJplD2e6t+pRRMEQoDX9bsDmbkA+A2wdnk6S7/VbqB4VQlBjV7bou5DZT3I//BfWdZ9f95xZi7NzHOppgOCarqiR4iIJ1A9WvGvVFP1SJoiQ6GkUXYb1SnANSPiEZMRR8SLaT5XXa99oKxPiYgXNu6MiJUjYs+J5hzswGlU3/c/Af8ZdRcxRsQOVPP2NVN7pN8/96AfU5KZf6K6VnBWRMzqVbsRcUBEPHOC7Wux7Iaeia6v3JHqGtBLWt28JOnRDIWSRlb5o/7R8vIbEXFpRJwaEb+gmqPwMwPqx9nAu6iOQP0gIn5fnmRyeunL7VRHrx515KqD97oPeAPVtZIfBq4u3/OPqK6r/GIpOtHj+84s62+Uvn2xLH05tVvnrLJ+QQ/bfCVwRXl6zLkRcUpEfI8qCG4CXMKy77derQ9nT7BPUguGQkkjLTM/TTV338+BLahuOngYeH1m/udUmuhRPz4DbAt8iermk92BF1HdPXwx8BbgWz16r/Opbq45h2rOwr3K+xwGfLYUm+imluOojmouoPqcDirL6r3oVwsnlvUbe9jmp4Fjqa6x3A7YD9iS6nT1QcDu2fBc64hYkepu5XuprjuU1IZomBNUksZCRNxONUXMOpl5x7D70ysR8Qbga8C5mfnyYfenJiK+TzWFzGaZ+cch9WFPqiOEn87Mdw+jD9J05pFCSWMnIp5CFQjvno6BMCLWiYhH3X0cETsCtWcfnzzQTk3uvVRTzhw1xD58gGri6o8NsQ/StGUolDQ2IuI5EXEa1dMwAL4yzP50YUtgfkT8pu7axSuBy6ie0vH1zDxjuF18pMz8P6rnOb8+IrYY9PtHxN5Up5mPzsy7Bv3+0jjw9LGksRERB1Jd8/dn4H+BD2Rmvye37rlyF+/7qB559ySqawL/CvyK6gjhKY3PA5akbhkKJUmS5OljSZIkGQolSZKEoVCSJEkYCiVJkoShUJIkSRgKJUmSBPz/QVGFH3ToKEgAAAAASUVORK5CYII=\n",
+      "text/plain": [
+       "<Figure size 720x720 with 1 Axes>"
+      ]
+     },
+     "metadata": {
+      "needs_background": "light"
+     },
+     "output_type": "display_data"
+    }
+   ],
+   "source": [
+    "plt.figure(figsize=(10,10))\n",
+    "plt.hist(traj_lengths_ns, range=(0, traj_lengths_ns.max()), bins=25)\n",
+    "plt.xlabel(\"Traj length (ns)\")\n",
+    "plt.ylabel(\"Number of CLONEs\")\n",
+    "plt.title(f\"p{project_number}: \"+str(traj_lengths_ns.sum()/1000)+ \" $\\mu$s\")\n",
+    "plt.savefig(\"p16465-traj-distribution.png\", dpi=300)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "id": "1db7bdee",
+   "metadata": {},
+   "outputs": [],
+   "source": []
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "lab_env3",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "lab_env3"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -220,6 +511,19 @@
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
    "version": "3.8.5"
+  },
+  "toc": {
+   "base_numbering": 1,
+   "nav_menu": {},
+   "number_sections": true,
+   "sideBar": true,
+   "skip_h1_title": false,
+   "title_cell": "Table of Contents",
+   "title_sidebar": "Contents",
+   "toc_cell": false,
+   "toc_position": {},
+   "toc_section_display": true,
+   "toc_window_display": false
   },
   "widgets": {
    "application/vnd.jupyter.widget-state+json": {


### PR DESCRIPTION
1. Detailed instructions are included in the README for installing and running plyvel on MacOS 
2. The jupyter notebook now contains a new section that generates a simple histogram of CLONE-lengths - this will be useful for visualizing how much data there is (and how long trajectories) . 